### PR TITLE
✨ feat: WebRTC 사용을 위한 Websocket + STOMP 연결 (offer/answer 로직)

### DIFF
--- a/src/main/java/com/grow/study_service/StudyServiceApplication.java
+++ b/src/main/java/com/grow/study_service/StudyServiceApplication.java
@@ -3,8 +3,10 @@ package com.grow.study_service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 
 @EnableWebSocket
+@EnableWebSocketMessageBroker // WebSocket 메시지 브로커를 활성화
 @SpringBootApplication
 public class StudyServiceApplication {
 

--- a/src/main/java/com/grow/study_service/board/config/WebSocketConfig.java
+++ b/src/main/java/com/grow/study_service/board/config/WebSocketConfig.java
@@ -1,0 +1,45 @@
+package com.grow.study_service.board.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * <h2>WebSocket 구성 클래스.</h2>
+ * 이 클래스는 WebSocket 프로토콜을 통해 클라이언트와 서버 간 실시간 양방향 통신을 가능하게 하며,
+ * pub-sub(발행-구독) 패턴을 지원하는 메시징 시스템을 구축합니다.
+ * STOMP 프로토콜을 사용한 엔드포인트 등록과 메시지 브로커 설정을 담당합니다.
+ *
+ * @author sun
+ * @version 1.0
+ * @since 2025-08-07
+ */
+@Configuration
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    /**
+     * 메시지 브로커를 구성하는 메서드.
+     * 클라이언트가 구독할 토픽 경로와 서버로 메시지를 보낼 접두사를 설정합니다.
+     *
+     * @param config 메시지 브로커 레지스트리 인스턴스.
+     */
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic"); // 클라이언트가 구독할 경로.
+        config.setApplicationDestinationPrefixes("/app"); // 클라이언트가 보낸 메시지를 처리하는 대상 경로.
+    }
+
+    /**
+     * STOMP 엔드포인트를 등록하는 메서드.
+     * 클라이언트가 WebSocket 연결을 시작할 수 있는 URL을 정의하며, 허용된 오리진을 설정합니다.
+     *
+     * @param registry STOMP 엔드포인트 레지스트리 인스턴스.
+     */
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry
+                .addEndpoint("/signaling") // 웹소켓 연결 엔드포인트 URL
+                .setAllowedOriginPatterns("*"); // 모든 도메인 허용
+    }
+}

--- a/src/main/java/com/grow/study_service/board/domain/enums/BoardType.java
+++ b/src/main/java/com/grow/study_service/board/domain/enums/BoardType.java
@@ -15,6 +15,12 @@ public enum BoardType {
     // 공지사항 게시판
     NOTICE("공지사항 게시판"),
 
+    // 비디오/음성 채팅 게시판
+    VIDEO_VOICE_CHAT("비디오/음성 채팅 게시판"),
+
+    // 문서 협업 게시판
+    COLLABORATIVE_DOCUMENT("문서 협업 게시판"),
+
     // 커스텀 게시판
     CUSTOM("커스텀 게시판");
 

--- a/src/main/java/com/grow/study_service/board/presentation/video/SignalingController.java
+++ b/src/main/java/com/grow/study_service/board/presentation/video/SignalingController.java
@@ -1,0 +1,70 @@
+package com.grow.study_service.board.presentation.video;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+/**
+ * <h2>WebRTC 시그널링 컨트롤러 클래스.</h2>
+ * 이 클래스는 클라이언트 간 offer와 answer를 처리하여 P2P 연결을 위한 시그널링을 담당합니다.
+ * Spring WebSocket을 사용하며, 특정 토픽으로 메시지를 브로드캐스트합니다.
+ * 로그를 통해 요청 수신을 기록하여 디버깅을 용이하게 합니다.
+ *
+ * @author sun
+ * @version 1.0
+ * @since 2025-08-07
+ */
+@Slf4j
+@Controller
+public class SignalingController {
+
+    /**
+     * Offer를 처리하는 메서드.
+     * 클라이언트 A가 보낸 offer를 받아 대상 클라이언트 B의 토픽으로 브로드캐스트합니다.
+     * 클라이언트는 /app/offer/{roomId}/{targetMemberId} 경로로 요청을 보냅니다.
+     *
+     * @param offer 클라이언트가 보낸 offer 데이터 (SDP 문자열).
+     * @param roomId 채팅방의 고유 식별자 (roomId).
+     * @param targetMemberId 대상 회원의 고유 식별자 (targetMemberId).
+     * @return 받은 offer 데이터를 그대로 반환하여 브로드캐스트.
+     */
+    /**
+     * 전송되는 문자열 예시
+     * {
+     *   "type": "offer",
+     *   "sdp": "v=0\r\no=- 6137031273746274589 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=group:BUNDLE (이하 생략)"
+     * }
+     */
+    @MessageMapping("/offer/{roomId}/{targetMemberId}")
+    @SendTo("/topic/peer/offer/{roomId}/{targetMemberId}")
+    public String handleOffer(@Payload String offer,
+                              @DestinationVariable String roomId,
+                              @DestinationVariable String targetMemberId) {
+        log.info("[Offer Received] 요청 수신 완료 | roomId={}, targetMemberId={}, offer=[{}]",
+                roomId, targetMemberId, offer);
+        return offer;
+    }
+
+    /**
+     * Answer를 처리하는 메서드.
+     * 클라이언트 B가 보낸 answer를 받아 대상 클라이언트 A의 토픽으로 브로드캐스트합니다.
+     * 클라이언트는 /app/peer/answer/{roomId}/{targetMemberId} 경로로 요청을 보냅니다.
+     *
+     * @param answer 클라이언트가 보낸 answer 데이터 (SDP 문자열).
+     * @param roomId 채팅방의 고유 식별자 (roomId).
+     * @param targetMemberId 대상 회원의 고유 식별자 (targetMemberId).
+     * @return 받은 answer 데이터를 그대로 반환하여 브로드캐스트.
+     */
+    @MessageMapping("/peer/answer/{roomId}/{targetMemberId}")
+    @SendTo("/topic/peer/answer/{roomId}/{targetMemberId}")
+    public String handleAnswer(@Payload String answer,
+                               @DestinationVariable String roomId,
+                               @DestinationVariable String targetMemberId) {
+        log.info("[Answer Received] 요청 수신 완료 | roomId={}, targetMemberId={}, answer=[{}]",
+                roomId, targetMemberId, answer);
+        return answer;
+    }
+}

--- a/src/main/java/com/grow/study_service/board/presentation/video/TestStompController.java
+++ b/src/main/java/com/grow/study_service/board/presentation/video/TestStompController.java
@@ -1,0 +1,20 @@
+package com.grow.study_service.board.presentation.video;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@Controller
+public class TestStompController {
+
+    // 간단한 STOMP 메시지 수신 테스트: 클라이언트가 "/app/test"로 메시지 보내면 로그 찍고 브로드캐스트
+    @MessageMapping("/test")  // 클라이언트가 "/app/test"로 send하면 이 메서드 호출
+    @SendTo("/topic/test")    // 응답을 "/topic/test" 토픽으로 브로드캐스트 (구독한 클라이언트가 받음)
+    public String test(@Payload String message) {
+        log.info("[STOMP Test] 메시지 수신 완료: {}", message);  // 전송 여부 확인을 위한 로그
+        return "테스트 응답: " + message;  // 받은 메시지를 반환
+    }
+}

--- a/src/main/resources/static/offer-test.html
+++ b/src/main/resources/static/offer-test.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.5.0/sockjs.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+</head>
+<body>
+<h1>STOMP OFFER 전송 테스트 클라이언트</h1>
+<button onclick="sendOffer()"> Offer </button>
+<script>
+    const socket = new WebSocket('ws://localhost:8080/signaling');
+    const stompClient = Stomp.over(socket);
+
+    stompClient.connect({}, () => {
+        console.log('STOMP 연결 성공');
+
+        // /topic/peer/offer/{roomId}/{targetMemberId} 구독 (브로드캐스트 받기 테스트)
+        stompClient.subscribe('/topic/peer/offer/1/1', (message) => {
+            console.log('수신된 Offer: ' + message.body);
+        });
+    });
+
+    function sendOffer() {
+        const offerData = JSON.stringify({ offer: 'test offer data' });  // @Payload로 받을 데이터
+        stompClient.send('/app/offer/1/1', {}, offerData);  // /app prefix + 매핑 경로
+        console.log('Offer 전송 완료');
+    }
+</script>
+</body>
+</html>

--- a/src/main/resources/static/test-stomp.html
+++ b/src/main/resources/static/test-stomp.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>STOMP 테스트 클라이언트</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.5.0/sockjs.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+</head>
+<body>
+<h1>STOMP 테스트 클라이언트</h1>
+<button onclick="connect()">연결하기</button>
+<button onclick="sendMessage()" disabled id="sendBtn">메시지 보내기</button>
+<button onclick="disconnect()">연결 끊기</button>
+<p>수신된 메시지: <span id="response"></span></p>
+
+<script>
+    let stompClient = null;
+    const sendButton = document.getElementById('sendBtn');
+
+    function connect() {
+        const socket = new WebSocket('ws://localhost:8080/signaling');
+        stompClient = Stomp.over(socket);
+
+        stompClient.connect({}, function (frame) {
+            console.log('STOMP 연결 성공: ' + frame);
+            sendButton.disabled = false;  // 연결 후 버튼 활성화
+
+            // /topic/test 토픽 구독: 서버가 브로드캐스트하는 메시지 수신
+            stompClient.subscribe('/topic/test', function (message) {
+                console.log('수신된 메시지: ' + message.body);
+                document.getElementById('response').innerText = message.body;  // 화면에 표시
+            });
+        }, function (error) {
+            console.error('STOMP 연결 오류: ' + error);
+        });
+    }
+
+    function sendMessage() {
+        if (stompClient) {
+            const testMessage = 'Hello STOMP! This is a test message.';  // 보낼 메시지 (JSON으로도 가능)
+            stompClient.send('/app/test', {}, testMessage);  // /app prefix + 매핑 경로로 전송
+            console.log('메시지 전송: ' + testMessage);
+        } else {
+            console.error('먼저 연결하세요!');
+        }
+    }
+
+    function disconnect() {
+        if (stompClient) {
+            stompClient.disconnect();
+            console.log('STOMP 연결 끊김');
+            sendButton.disabled = true;
+        }
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`localhost:8080`)
    2. 웹소켓 연결 로직 실행 (테스트 클라이언트 코드)
    3. 웹소켓 연결 후 offer 전송 로직 실행 (테스트 클라이언트 코드)

+ 📸 Screenshot or Test Result

<img width="874" height="582" alt="스크린샷 2025-08-07 오후 11 14 01" src="https://github.com/user-attachments/assets/3ffb2d69-2ceb-49b4-a3bb-764402d283f0" />

- 포스트맨에서 웹소켓 연결 테스트 진행 

<img width="540" height="249" alt="스크린샷 2025-08-07 오후 11 38 43" src="https://github.com/user-attachments/assets/ed8517eb-c5a5-448e-ad2a-8aecf4a52d34" />
<img width="1129" height="147" alt="스크린샷 2025-08-07 오후 11 38 50" src="https://github.com/user-attachments/assets/22665018-4de8-4341-bf40-35bf7d51f70f" />

- 테스트 클라이언트 코드를 생성해서 연결 테스트 진행
- 서버 로그 확인 가능

<img width="586" height="210" alt="스크린샷 2025-08-07 오후 11 38 56" src="https://github.com/user-attachments/assets/7bd4f95d-9c0e-48d5-bded-e29d1dfc2712" />
<img width="1606" height="158" alt="스크린샷 2025-08-07 오후 11 39 16" src="https://github.com/user-attachments/assets/006d9e80-1cd7-406a-9536-c4c6a5090533" />

- 테스트 클라이언트 코드에서 메세지 (STOMP 활용) 전송
- 서버 로그 확인 가능 

<img width="586" height="226" alt="스크린샷 2025-08-07 오후 11 43 33" src="https://github.com/user-attachments/assets/4d25b259-568e-4c36-a258-8ccfaccbf6cb" />
<img width="967" height="101" alt="스크린샷 2025-08-07 오후 11 43 24" src="https://github.com/user-attachments/assets/37e1fa2a-95c1-40cb-815f-11cdf15a2148" />

- 테스트 클라이언트 코드 생성하여 offer 을 전송할 수 있도록 함
- 서버 로그 확인 가능

## 🔗 Related Issues(필수)
Closes #{1}

## 📝 Note (주의 사항)
WebRTC란?
웹 브라우저에서 앱 설치 없이 실시간으로 영상, 음성, 데이터 등을 주고받을 수 있게 해주는 기술
예: 웹사이트에서 바로 화상 통화나 채팅 가능

서버의 주요 역할 -> 시그널링 과정
WebSocket/STOMP 등의 기술로 클라이언트 간 정보를 중계함
1. Offer/Answer 교환
목적: 양측 클라이언트가 미디어 설정(카메라, 마이크, 코덱 등)을 합의하기 위함
합의되지 않으면 연결 불가
Offer: 한 쪽이 SDP 형식으로 "내 설정은 이래, 연결할래?" 제안
Answer: 상대가 "좋아, 나도 맞출게" 응답
서버 역할: Offer와 Answer를 클라이언트 A와 B 간 전달
결과: 이 과정 완료 시 기본 연결 구조 완성

현재는 위의 Offer/Answer 과정을 진행하기 위해서 컨트롤러를 생성했습니다
추가적인 연결 로직이 필요합니다 (ICE Candidates 교환 등)