### PR TITLE
✨ feat: 공지사항 조회를 위한 API 엔드포인트 생성

### DIFF
--- a/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
+++ b/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     GROUP_MEMBER_JOINED_AT_IS_EMPTY("400", "그룹 멤버가 가입한 시각은 비어있을 수 없습니다."),
     GROUP_MEMBER_ID_IS_EMPTY("400", "그룹 멤버 아이디는 비어있을 수 없습니다."),
     GROUP_MEMBER_NOT_FOUND("404", "그룹 멤버를 찾을 수 없습니다."),
+    MEMBER_NOT_IN_GROUP("403", "그룹 멤버가 아닙니다." ),
 
     /**
      * 📌 3. 게시판(Board) 관련

--- a/src/main/java/com/grow/study_service/groupmember/domain/model/GroupMember.java
+++ b/src/main/java/com/grow/study_service/groupmember/domain/model/GroupMember.java
@@ -47,141 +47,141 @@ public class GroupMember {
 	 */
 	private final LocalDateTime joinedAt;
 
-	/**
-	 * 새로운 그룹 멤버를 생성하는 팩토리 메서드.
-	 * 그룹 멤버 ID는 null로 설정되며, 데이터베이스 삽입 시 자동 생성됩니다.
-	 *
-	 * @param memberId 멤버 ID. null 또는 0 이하일 수 없음.
-	 * @param groupId 그룹 ID. null 또는 0 이하일 수 없음.
-	 * @param role 멤버 역할. null일 수 없음.
-	 * @return 새로 생성된 GroupMember 인스턴스.
-	 * @throws DomainException 매개변수가 유효하지 않으면 예외 발생.
-	 */
-	public static GroupMember create(Long memberId,
-									 Long groupId,
-									 Role role
-	) {
+    /**
+     * 새로운 그룹 멤버를 생성하는 팩토리 메서드.
+     * 그룹 멤버 ID는 null로 설정되며, 데이터베이스 삽입 시 자동 생성됩니다.
+     *
+     * @param memberId 멤버 ID. null 또는 0 이하일 수 없음.
+     * @param groupId  그룹 ID. null 또는 0 이하일 수 없음.
+     * @param role     멤버 역할. null일 수 없음.
+     * @return 새로 생성된 GroupMember 인스턴스.
+     * @throws DomainException 매개변수가 유효하지 않으면 예외 발생.
+     */
+    public static GroupMember create(Long memberId,
+                                     Long groupId,
+                                     Role role
+    ) {
 
-		verifyParameters(memberId, groupId, role);
-		return new GroupMember(
-				null,
-				memberId,
-				groupId,
-				role,
-				LocalDateTime.now() // 데이터베이스에 저장될 때는 현재 시각을 사용함. (자동 생성)
-		);
-	}
+        verifyParameters(memberId, groupId, role);
+        return new GroupMember(
+                null,
+                memberId,
+                groupId,
+                role,
+                LocalDateTime.now() // 데이터베이스에 저장될 때는 현재 시각을 사용함. (자동 생성)
+        );
+    }
 
-	/**
-	 * 기존 그룹 멤버 정보를 바탕으로 GroupMember 인스턴스를 생성하는 팩토리 메서드.
-	 * 주로 데이터베이스 조회 결과를 매핑할 때 사용됩니다.
-	 *
-	 * @param groupMemberId 그룹 멤버 ID.
-	 * @param memberId 멤버 ID.
-	 * @param groupId 그룹 ID.
-	 * @param role 멤버 역할.
-	 * @param joinedAt 가입 시각.
-	 * @return 조회된 정보를 담은 GroupMember 인스턴스.
-	 * @throws DomainException 매개변수가 유효하지 않으면 예외 발생.
-	 */
-	public static GroupMember of(Long groupMemberId,
-								 Long memberId,
-								 Long groupId,
-								 Role role,
-								 LocalDateTime joinedAt
-	) {
-		verifyParameters(memberId, groupId, role);
-		verifyIdAndJoinedAt(groupMemberId, joinedAt);
+    /**
+     * 기존 그룹 멤버 정보를 바탕으로 GroupMember 인스턴스를 생성하는 팩토리 메서드.
+     * 주로 데이터베이스 조회 결과를 매핑할 때 사용됩니다.
+     *
+     * @param groupMemberId 그룹 멤버 ID.
+     * @param memberId      멤버 ID.
+     * @param groupId       그룹 ID.
+     * @param role          멤버 역할.
+     * @param joinedAt      가입 시각.
+     * @return 조회된 정보를 담은 GroupMember 인스턴스.
+     * @throws DomainException 매개변수가 유효하지 않으면 예외 발생.
+     */
+    public static GroupMember of(Long groupMemberId,
+                                 Long memberId,
+                                 Long groupId,
+                                 Role role,
+                                 LocalDateTime joinedAt
+    ) {
+        verifyParameters(memberId, groupId, role);
+        verifyIdAndJoinedAt(groupMemberId, joinedAt);
 
-		return new GroupMember(
-				groupMemberId,
-				memberId,
-				groupId,
-				role,
-				joinedAt
-		);
-	}
+        return new GroupMember(
+                groupMemberId,
+                memberId,
+                groupId,
+                role,
+                joinedAt
+        );
+    }
 
-	/**
-	 * 매개변수의 유효성을 검사하는 private 메서드.
-	 * 생성 또는 조회 시 매개변수가 적절한지 확인합니다.
-	 *
-	 * @param memberId 멤버 ID.
-	 * @param groupId 그룹 ID.
-	 * @param role 멤버 역할.
-	 * @throws DomainException 매개변수가 null 또는 유효하지 않으면 예외 발생.
-	 */
-	private static void verifyParameters(Long memberId,
-										 Long groupId,
-										 Role role) {
+    /**
+     * 매개변수의 유효성을 검사하는 private 메서드.
+     * 생성 또는 조회 시 매개변수가 적절한지 확인합니다.
+     *
+     * @param memberId 멤버 ID.
+     * @param groupId  그룹 ID.
+     * @param role     멤버 역할.
+     * @throws DomainException 매개변수가 null 또는 유효하지 않으면 예외 발생.
+     */
+    private static void verifyParameters(Long memberId,
+                                         Long groupId,
+                                         Role role) {
 
-		if (memberId == null || memberId <= 0L) {
-			throw new DomainException(ErrorCode.GROUP_MEMBER_MEMBER_ID_IS_EMPTY);
-		}
+        if (memberId == null || memberId <= 0L) {
+            throw new DomainException(ErrorCode.GROUP_MEMBER_MEMBER_ID_IS_EMPTY);
+        }
 
-		if (groupId == null || groupId <= 0L) {
-			throw new DomainException(ErrorCode.GROUP_MEMBER_GROUP_ID_IS_EMPTY);
-		}
+        if (groupId == null || groupId <= 0L) {
+            throw new DomainException(ErrorCode.GROUP_MEMBER_GROUP_ID_IS_EMPTY);
+        }
 
-		if (role == null) {
-			throw new DomainException(ErrorCode.GROUP_MEMBER_ROLE_IS_EMPTY);
-		}
-	}
+        if (role == null) {
+            throw new DomainException(ErrorCode.GROUP_MEMBER_ROLE_IS_EMPTY);
+        }
+    }
 
-	/**
-	 * ID와 가입 시각의 유효성을 검사하는 private 메서드.
-	 * 조회 시 ID와 joinedAt가 적절한지 확인합니다.
-	 *
-	 * @param groupMemberId 그룹 멤버 ID.
-	 * @param joinedAt 가입 시각.
-	 * @throws DomainException 매개변수가 null 또는 유효하지 않으면 예외 발생.
-	 */
-	private static void verifyIdAndJoinedAt(Long groupMemberId, LocalDateTime joinedAt) {
-		if (joinedAt == null) {
-			throw new DomainException(ErrorCode.GROUP_MEMBER_JOINED_AT_IS_EMPTY);
-		}
+    /**
+     * ID와 가입 시각의 유효성을 검사하는 private 메서드.
+     * 조회 시 ID와 joinedAt가 적절한지 확인합니다.
+     *
+     * @param groupMemberId 그룹 멤버 ID.
+     * @param joinedAt      가입 시각.
+     * @throws DomainException 매개변수가 null 또는 유효하지 않으면 예외 발생.
+     */
+    private static void verifyIdAndJoinedAt(Long groupMemberId, LocalDateTime joinedAt) {
+        if (joinedAt == null) {
+            throw new DomainException(ErrorCode.GROUP_MEMBER_JOINED_AT_IS_EMPTY);
+        }
 
-		if (groupMemberId == null || groupMemberId <= 0L) {
-			throw new DomainException(ErrorCode.GROUP_MEMBER_ID_IS_EMPTY);
-		}
-	}
+        if (groupMemberId == null || groupMemberId <= 0L) {
+            throw new DomainException(ErrorCode.GROUP_MEMBER_ID_IS_EMPTY);
+        }
+    }
 
-	// ==== 업데이트 메서드 ==== //
+    // ==== 업데이트 메서드 ==== //
 
-	/**
-	 * 멤버 역할을 업데이트하는 메서드.
-	 * 새로운 역할이 기존 역할과 다를 경우에만 업데이트하며, null 값은 허용되지 않습니다.
-	 *
-	 * @param newRole 새로운 멤버 역할.
-	 * @throws DomainException 새 역할이 null일 경우 예외 발생.
-	 */
-	public void updateRole(Role newRole) {
-		if (newRole == null) {
-			throw new DomainException(ErrorCode.GROUP_MEMBER_ROLE_IS_EMPTY);
-		}
+    /**
+     * 멤버 역할을 업데이트하는 메서드.
+     * 새로운 역할이 기존 역할과 다를 경우에만 업데이트하며, null 값은 허용되지 않습니다.
+     *
+     * @param newRole 새로운 멤버 역할.
+     * @throws DomainException 새 역할이 null일 경우 예외 발생.
+     */
+    public void updateRole(Role newRole) {
+        if (newRole == null) {
+            throw new DomainException(ErrorCode.GROUP_MEMBER_ROLE_IS_EMPTY);
+        }
 
-		if (!this.role.equals(newRole)) {
-			this.role = newRole;
-		}
-	}
+        if (!this.role.equals(newRole)) {
+            this.role = newRole;
+        }
+    }
 
-	/**
-	 * 그룹 리더인지 여부를 검증하는 메서드.
-	 * <p>
-	 * 전달받은 {@link Role}이 {@code LEADER}가 아닐 경우
-	 * {@link DomainException}을 발생시켜 호출 흐름을 중단한다.
-	 * </p>
-	 *
-	 * <p>이 메서드는 주로 그룹장 권한이 필요한 서비스 로직에서
-	 * 사전 권한 체크용으로 사용된다.</p>
-	 *
-	 * @param role 검증할 사용자의 역할
-	 * @throws DomainException 사용자의 역할이 {@code LEADER}가 아닐 경우
-	 *                         {@link ErrorCode#GROUP_LEADER_REQUIRED} 코드와 함께 예외가 발생한다.
-	 */
-	public void verifyGroupLeader(Role role) {
-		if (role != Role.LEADER) {
-			throw new DomainException(ErrorCode.GROUP_LEADER_REQUIRED);
-		}
-	}
+    /**
+     * 그룹 리더인지 여부를 검증하는 메서드.
+     * <p>
+     * 전달받은 {@link Role}이 {@code LEADER}가 아닐 경우
+     * {@link DomainException}을 발생시켜 호출 흐름을 중단한다.
+     * </p>
+     *
+     * <p>이 메서드는 주로 그룹장 권한이 필요한 서비스 로직에서
+     * 사전 권한 체크용으로 사용된다.</p>
+     *
+     * @param role 검증할 사용자의 역할
+     * @throws DomainException 사용자의 역할이 {@code LEADER}가 아닐 경우
+     *                         {@link ErrorCode#GROUP_LEADER_REQUIRED} 코드와 함께 예외가 발생한다.
+     */
+    public void verifyGroupLeader(Role role) {
+        if (role != Role.LEADER) {
+            throw new DomainException(ErrorCode.GROUP_LEADER_REQUIRED);
+        }
+    }
 }

--- a/src/main/java/com/grow/study_service/groupmember/domain/repository/GroupMemberRepository.java
+++ b/src/main/java/com/grow/study_service/groupmember/domain/repository/GroupMemberRepository.java
@@ -1,6 +1,5 @@
 package com.grow.study_service.groupmember.domain.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import com.grow.study_service.groupmember.domain.model.GroupMember;
@@ -10,4 +9,5 @@ public interface GroupMemberRepository {
 	Optional<GroupMember> findById(Long groupMemberId);
 	void delete(GroupMember member);
 	Optional<GroupMember> findGroupMemberByMemberIdAndGroupId(Long memberId, Long groupId);
+	boolean existsByGroupIdAndMemberId(Long groupId, Long memberId);
 }

--- a/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberJpaRepository.java
+++ b/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberJpaRepository.java
@@ -1,6 +1,5 @@
 package com.grow.study_service.groupmember.infra.persistence.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +8,6 @@ import com.grow.study_service.groupmember.infra.persistence.entity.GroupMemberJp
 
 public interface GroupMemberJpaRepository
 	extends JpaRepository<GroupMemberJpaEntity, Long> {
-	List<GroupMemberJpaEntity> findByGroupId(Long groupId);
 	Optional<GroupMemberJpaEntity> findByMemberIdAndGroupId(Long memberId, Long groupId);
+	boolean existsByGroupIdAndMemberId(Long groupId, Long memberId);
 }

--- a/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberRepositoryImpl.java
+++ b/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberRepositoryImpl.java
@@ -53,4 +53,20 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepository {
 		return groupMemberJpaRepository.findByMemberIdAndGroupId(memberId, groupId)
 				.map(GroupMemberMapper::toDomain);
 	}
+
+	/**
+	 * 지정된 그룹에 특정 회원이 속해 있는지 여부를 확인한다.
+	 * <p>
+	 * DB에서 해당 그룹 ID와 회원 ID로 검색하여 존재 여부를 반환한다.
+	 * </p>
+	 *
+	 * @param groupId  그룹 ID
+	 * @param memberId 회원 ID
+	 * @return {@code true} - 해당 회원이 그룹에 속한 경우,
+	 *         {@code false} - 속하지 않은 경우
+	 */
+	@Override
+	public boolean existsByGroupIdAndMemberId(Long groupId, Long memberId) {
+		return groupMemberJpaRepository.existsByGroupIdAndMemberId(groupId, memberId);
+	}
 }

--- a/src/main/java/com/grow/study_service/notice/application/service/NoticeService.java
+++ b/src/main/java/com/grow/study_service/notice/application/service/NoticeService.java
@@ -1,5 +1,6 @@
 package com.grow.study_service.notice.application.service;
 
+import com.grow.study_service.notice.presentation.dto.NoticeResponse;
 import com.grow.study_service.notice.presentation.dto.NoticeSaveRequest;
 import com.grow.study_service.notice.presentation.dto.NoticeUpdateRequest;
 
@@ -8,4 +9,5 @@ import java.util.List;
 public interface NoticeService {
     void saveNotice(Long memberId, NoticeSaveRequest request);
     void updateNotices(Long groupId, Long memberId, List<NoticeUpdateRequest> request);
+    List<NoticeResponse> getNotices(Long groupId, Long memberId);
 }

--- a/src/main/java/com/grow/study_service/notice/application/service/NoticeServiceImpl.java
+++ b/src/main/java/com/grow/study_service/notice/application/service/NoticeServiceImpl.java
@@ -42,32 +42,47 @@ public class NoticeServiceImpl implements NoticeService {
     @Override
     @Transactional
     public void saveNotice(Long memberId, NoticeSaveRequest request) {
-        log.info("[Notice Save] 공지사항 저장 시작 (1/2)");
+        log.info("[NOTICE][SAVE][START] memberId={}, contentLength={} - 공지사항 저장 요청 시작",
+                memberId, request.getContent().length());
 
+        // 권한 검증
         verifyAuthentification(memberId, request.getGroupId());
 
-        noticeRepository.save(
-                Notice.create(
-                        request.getGroupId(),
-                        request.getContent(),
-                        request.getIsPinned()
-                ));
-        log.info("[Notice Save] 공지사항 저장 완료 (2/2)");
+        // 저장 처리
+        Notice notice = Notice.create(request.getGroupId(), request.getContent(), request.getIsPinned());
+        noticeRepository.save(notice);
+
+        log.info("[NOTICE][SAVE][END] memberId={}, groupId={}, noticeId={} - 공지사항 저장 성공",
+                memberId, request.getGroupId(), notice.getNoticeId());
     }
 
+    /**
+     * 지정된 그룹의 공지사항들을 일괄 업데이트한다.
+     * <p>
+     * 1. 요청 회원이 해당 그룹의 그룹장인지 권한 검증<br>
+     * 2. 권한이 있으면 요청 목록의 각 공지사항을 순회하며 내용·고정 여부를 수정<br>
+     * 3. 수정된 건수를 로그에 기록
+     * </p>
+     *
+     * @param groupId  수정할 그룹 ID
+     * @param memberId 수정 요청 회원 ID
+     * @param requests 수정할 공지사항 요청 목록
+     * @throws ServiceException 그룹장 권한이 없거나, ID에 해당하는 공지가 존재하지 않는 경우
+     */
     @Override
     @Transactional
     public void updateNotices(Long groupId,
                               Long memberId,
-                              List<NoticeUpdateRequest> request) {
+                              List<NoticeUpdateRequest> requests) {
+        log.info("[NOTICE][UPDATE][START] groupId={}, memberId={}, requestCount={} - 공지사항 업데이트 시작",
+                groupId, memberId, requests.size());
+
         // 임시 저장용 공지사항 목록
         List<Notice> notices = new ArrayList<>();
 
-        log.info("[Notice Save] 공지사항 업데이트 시작 (1/2)");
-
         verifyAuthentification(memberId, groupId);
 
-        for (NoticeUpdateRequest n : request) {
+        for (NoticeUpdateRequest n : requests) {
             log.info("[Notice Save] 공지사항 저장: 내용={}", n.getContent());
             notices.add(
                     new Notice(
@@ -81,35 +96,71 @@ public class NoticeServiceImpl implements NoticeService {
 
         noticeRepository.saveAll(notices);
 
-        log.info("[Notice Save] 공지사항 업데이트 완료 (2/2)");
+        log.info("[NOTICE][UPDATE][END] groupId={}, memberId={}, updatedCount={} - 공지사항 업데이트 완료",
+                groupId, memberId, requests.size());
     }
 
+    /**
+     * 특정 그룹의 공지사항 목록을 조회한다.
+     * <p>
+     * 1. 요청 회원이 해당 그룹에 속하는지 권한 검증
+     * 2. 그룹 ID로 공지사항 조회
+     * 3. 엔티티를 {@link NoticeResponse} DTO로 변환 후 반환
+     * </p>
+     *
+     * @param groupId  조회할 그룹 ID
+     * @param memberId 요청 회원 ID
+     * @return 해당 그룹의 공지사항 목록
+     * @throws ServiceException 요청 회원이 그룹에 속하지 않은 경우
+     *                           ({@link ErrorCode#MEMBER_NOT_IN_GROUP})
+     */
     @Override
+    @Transactional(readOnly = true)
     public List<NoticeResponse> getNotices(Long groupId, Long memberId) {
-        // 멤버가 해당 그룹의 멤버인지 권한 검사
-        log.info("[Notice Find] 공지사항 조회 시작 (1/2)");
-        boolean isMember = groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId);
+        log.info("[NOTICE][GET][START] groupId={}, memberId={} - 공지사항 조회 요청 시작", groupId, memberId);
 
+        // 1. 권한 검사
+        boolean isMember = groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId);
         if (!isMember) {
+            log.warn("[NOTICE][GET][UNAUTHORIZED] groupId={}, memberId={} - 그룹 멤버 아님", groupId, memberId);
             throw new ServiceException(ErrorCode.MEMBER_NOT_IN_GROUP);
         }
 
-        // 공지사항 조회
+        // 2. 공지사항 조회
         List<Notice> noticeList = noticeRepository.findByGroupId(groupId);
-        log.info("[Notice Find] 공지사항 조회 완료 (2/2)");
+        log.info("[NOTICE][GET][DB] groupId={} - {}건 조회 완료", groupId, noticeList.size());
 
-        return noticeList.stream()
+        // 3. 변환
+        List<NoticeResponse> responseList = noticeList.stream()
                 .map(n -> new NoticeResponse(n.getNoticeId(), n.getContent(), n.isPinned()))
                 .toList();
+
+        log.info("[NOTICE][GET][END] groupId={}, memberId={}, resultSize={} - 공지사항 조회 성공",
+                groupId, memberId, responseList.size());
+
+        return responseList;
     }
 
+    /**
+     * 지정된 그룹에서 해당 회원이 그룹장 권한을 가지고 있는지 검증한다.
+     * <p>
+     * 1. 멤버 ID와 그룹 ID로 그룹 멤버 정보를 조회
+     * 2. 조회한 멤버의 역할(Role)이 그룹장인지 확인
+     * </p>
+     *
+     * @param memberId 검증할 회원 ID
+     * @param groupId  검증 대상 그룹 ID
+     * @throws ServiceException 해당 멤버가 그룹에 존재하지 않는 경우
+     *                           ({@link ErrorCode#GROUP_MEMBER_NOT_FOUND})
+     * @throws DomainException  멤버가 그룹장이 아닌 경우
+     */
     private void verifyAuthentification(Long memberId, Long groupId) {
-        // 권한 검증을 위해 멤버 ID와 그룹 ID를 조합하여 조회
+        // 멤버 ID와 그룹 ID로 그룹 멤버 조회 (없으면 예외)
         GroupMember groupMember = groupMemberRepository
                 .findGroupMemberByMemberIdAndGroupId(memberId, groupId)
                 .orElseThrow(() -> new ServiceException(ErrorCode.GROUP_MEMBER_NOT_FOUND));
 
-        // 권한 검증 로직 수행
+        // 그룹장 권한 검증 (도메인 객체 내 로직 사용)
         groupMember.verifyGroupLeader(groupMember.getRole());
     }
 }

--- a/src/main/java/com/grow/study_service/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/com/grow/study_service/notice/domain/repository/NoticeRepository.java
@@ -9,4 +9,5 @@ public interface NoticeRepository {
     void save(Notice notice);
     void saveAll(List<Notice> notices);
     Optional<Notice> findByNoticeId(Long noticeId);
+    List<Notice> findByGroupId(Long groupId);
 }

--- a/src/main/java/com/grow/study_service/notice/infra/repository/NoticeJpaRepository.java
+++ b/src/main/java/com/grow/study_service/notice/infra/repository/NoticeJpaRepository.java
@@ -3,5 +3,8 @@ package com.grow.study_service.notice.infra.repository;
 import com.grow.study_service.notice.infra.entity.NoticeJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NoticeJpaRepository extends JpaRepository<NoticeJpaEntity, Long> {
+    List<NoticeJpaEntity> findByGroupId(Long groupId);
 }

--- a/src/main/java/com/grow/study_service/notice/infra/repository/NoticeRepositoryImpl.java
+++ b/src/main/java/com/grow/study_service/notice/infra/repository/NoticeRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.grow.study_service.notice.domain.model.Notice;
 import com.grow.study_service.notice.domain.repository.NoticeRepository;
 import com.grow.study_service.notice.infra.entity.NoticeJpaEntity;
 import com.grow.study_service.notice.infra.mapper.NoticeMapper;
+import com.grow.study_service.notice.presentation.dto.NoticeResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -54,5 +55,13 @@ public class NoticeRepositoryImpl implements NoticeRepository {
     public Optional<Notice> findByNoticeId(Long noticeId) {
         return noticeJpaRepository.findById(noticeId)
                 .map(mapper::toDomain);
+    }
+
+    @Override
+    public List<Notice> findByGroupId(Long groupId) {
+        List<Notice> list = noticeJpaRepository.findByGroupId(groupId).stream()
+                .map(mapper::toDomain)
+                .toList();
+        return list;
     }
 }

--- a/src/main/java/com/grow/study_service/notice/presentation/controller/NoticeController.java
+++ b/src/main/java/com/grow/study_service/notice/presentation/controller/NoticeController.java
@@ -3,6 +3,7 @@ package com.grow.study_service.notice.presentation.controller;
 import com.grow.study_service.common.exception.domain.DomainException;
 import com.grow.study_service.common.rsdata.RsData;
 import com.grow.study_service.notice.application.service.NoticeService;
+import com.grow.study_service.notice.presentation.dto.NoticeResponse;
 import com.grow.study_service.notice.presentation.dto.NoticeSaveRequest;
 import com.grow.study_service.notice.presentation.dto.NoticeUpdateRequest;
 import jakarta.validation.Valid;
@@ -76,7 +77,27 @@ public class NoticeController {
         );
     }
 
-    // 공지사항 조회 API
+    /**
+     * 특정 그룹의 모든 공지사항을 조회하는 API.
+     * <p>회원이 해당 그룹에 속해 있는지 검증 후, 공지사항 목록을 반환한다.</p>
+     *
+     * @param groupId  PathVariable - 조회할 그룹 ID
+     * @param memberId RequestHeader("X-Authorization-Id") - 요청 회원 ID
+     * @return 공지사항 목록과 처리 결과를 담은 {@link RsData}
+     *
+     * @throws DomainException 요청자가 그룹에 속하지 않았거나 접근 권한이 없는 경우
+     */
+    @GetMapping("/{groupId}")
+    public RsData<List<NoticeResponse>> getNotices(@PathVariable("groupId") Long groupId,
+                                                   @RequestHeader("X-Authorization-Id") Long memberId) {
+
+        List<NoticeResponse> notices = noticeService.getNotices(groupId, memberId);
+
+        return new RsData<>("200",
+                "공지사항 조회 완료",
+                notices
+        );
+    }
 
     // 공지사항 삭제 API
 }

--- a/src/main/java/com/grow/study_service/notice/presentation/dto/NoticeResponse.java
+++ b/src/main/java/com/grow/study_service/notice/presentation/dto/NoticeResponse.java
@@ -1,0 +1,20 @@
+package com.grow.study_service.notice.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeResponse {
+
+    /** 공지사항 ID */
+    private Long noticeId;
+
+    /** 공지 내용 */
+    private String content;
+
+    /** 상단 고정 여부 */
+    private boolean isPinned;
+}

--- a/src/main/java/com/grow/study_service/notice/presentation/dto/NoticeUpdateRequest.java
+++ b/src/main/java/com/grow/study_service/notice/presentation/dto/NoticeUpdateRequest.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class NoticeUpdateRequest {
 
+    /** 공지 ID (필수) */
     @NotNull(message = "공지 ID는 필수입니다.")
     private Long noticeId;
 


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (postman)

+ 📸 Screenshot or Test Result

<img width="395" height="129" alt="스크린샷 2025-08-13 오후 9 59 35" src="https://github.com/user-attachments/assets/5b6d60f4-7475-4a2a-9946-8b42621265b2" />

- 두 가지 값이 들어있다고 가정

<img width="894" height="720" alt="스크린샷 2025-08-13 오후 10 00 15" src="https://github.com/user-attachments/assets/fcd63ee0-a8c1-474d-8dc8-19f8fe996522" />

- 정상 상황일 때에는 성공 응답 도출 (리더인지 멤버인지 구분하지 않음)

<img width="890" height="632" alt="스크린샷 2025-08-13 오후 10 00 23" src="https://github.com/user-attachments/assets/b02882d3-6ae8-4607-b08e-6010f6b73046" />

- 그룹의 멤버가 아닐 경우에는 오류 발생

<img width="921" height="602" alt="스크린샷 2025-08-13 오후 6 20 24" src="https://github.com/user-attachments/assets/e013c861-0a9f-4da9-9df5-2350e4d7f470" />

- 이전 PR 에서 수정한다고 했던 건데, 공지 등록 중 리더가 아닐 경우 위와 같은 오류 메시지 뜹니다!!! (일단 리더에게만 추가하기 버튼이 보일 수 있으면 좋겠는데, 이거 프론트에서 어케 하는지 함 찾아 볼게요)

## 🔗 Related Issues(필수)

Closes #{이슈 번호}

## 📝 Note (주의 사항)

1. [✨ feat: 공지사항 조회를 위한 서비스 로직 구현](https://github.com/Difficulty-accepting-feedback/study-service/commit/1ae891f06a0d613fd71b257217696bc396ce2a78) 의 getNotices 메서드에서 권한 검사를 도메인에서 실행할 수 있는 방안이 있는지 한 번 체크해 봐야겠습니다... group 과 groupmember 가 나뉘어있어서 약간 능지가 딸렸습니다... (밤 열시라 그런지 ^^) 
2. [📝 docs: 운영 모니터링을 위한 주석 추가 및 공백 정리](https://github.com/Difficulty-accepting-feedback/study-service/commit/3d751e901187c6b04f5b088878dd94d86b4eee31) 에서 서비스 로직 주석 추가하며 조회 용도의 트랜잭션 설정 추가해 뒀습니다 @Transactional(readOnly = true)
