### PR TITLE
✨ feat: 글 수정 API 엔드포인트 구현

### DIFF
--- a/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
+++ b/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
@@ -59,7 +59,11 @@ public enum ErrorCode {
     FILE_UPLOAD_FAILED("500", "파일 업로드에 실패했습니다." ),
     POST_NOT_FOUND("404", "게시글을 찾을 수 없습니다." ),
     FILE_NOT_FOUND("404", "파일을 찾을 수 없습니다." ),
-    FILE_PATH_INVALID("400", "파일 경로가 올바르지 않습니다."),;
+    FILE_PATH_INVALID("400", "파일 경로가 올바르지 않습니다."),
+    NOT_AUTHORIZED_USER("403", "글을 수정할 권한이 없습니다." ),
+    FILE_DELETE_FAILED("500", "파일 삭제에 실패했습니다." ),
+    ;
+
     private final String code;
     private final String message;
 }

--- a/src/main/java/com/grow/study_service/post/application/file/FileService.java
+++ b/src/main/java/com/grow/study_service/post/application/file/FileService.java
@@ -9,6 +9,6 @@ import java.util.List;
 public interface FileService {
     List<FileMeta> storeFilesForPost(Long postId, List<MultipartFile> files);
     Resource getDownloadLink(Long fileId);
-
     FileMeta getFileMeta(Long fileId);
+    void deleteFilesForPost(Long postId);
 }

--- a/src/main/java/com/grow/study_service/post/application/save/PostSaveService.java
+++ b/src/main/java/com/grow/study_service/post/application/save/PostSaveService.java
@@ -1,6 +1,7 @@
 package com.grow.study_service.post.application.save;
 
 import com.grow.study_service.post.presentation.dto.request.PostSaveRequest;
+import com.grow.study_service.post.presentation.dto.request.PostUpdateRequest;
 import com.grow.study_service.post.presentation.dto.response.PostResponse;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -8,4 +9,5 @@ import java.util.List;
 
 public interface PostSaveService {
     PostResponse createPost(Long memberId, PostSaveRequest request, List<MultipartFile> files);
+    void updatePost(Long memberId, Long postId, PostUpdateRequest request, List<MultipartFile> files);
 }

--- a/src/main/java/com/grow/study_service/post/application/save/PostSaveServiceImpl.java
+++ b/src/main/java/com/grow/study_service/post/application/save/PostSaveServiceImpl.java
@@ -1,10 +1,13 @@
 package com.grow.study_service.post.application.save;
 
+import com.grow.study_service.common.exception.ErrorCode;
+import com.grow.study_service.common.exception.service.ServiceException;
 import com.grow.study_service.post.application.file.FileService;
 import com.grow.study_service.post.domain.model.FileMeta;
 import com.grow.study_service.post.domain.model.Post;
 import com.grow.study_service.post.domain.repository.PostRepository;
 import com.grow.study_service.post.presentation.dto.request.PostSaveRequest;
+import com.grow.study_service.post.presentation.dto.request.PostUpdateRequest;
 import com.grow.study_service.post.presentation.dto.response.PostResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,7 +56,7 @@ public class PostSaveServiceImpl implements PostSaveService {
     @Override
     @Transactional
     public PostResponse createPost(Long memberId, PostSaveRequest request, List<MultipartFile> files) {
-        log.info("[NOTICE][POST][SAVE][START] 게시물 저장 시작 - memberId={}, boardId={}, fileCount={}",
+        log.info("[POST][SAVE][START] 게시물 저장 시작 - memberId={}, boardId={}, fileCount={}",
                 memberId, request.getBoardId(), (files == null ? 0 : files.size()));
 
         Post post = Post.create(
@@ -64,15 +67,59 @@ public class PostSaveServiceImpl implements PostSaveService {
         );
 
         Post saved = postRepository.save(post);
-        log.info("[NOTICE][POST][SAVED] postId={}, boardId={}, memberId={}",
+        log.info("[POST][SAVED] postId={}, boardId={}, memberId={}",
                 saved.getPostId(), saved.getBoardId(), saved.getMemberId());
 
         List<FileMeta> savedMetas = (files == null || files.isEmpty())
                 ? Collections.emptyList() // 파일이 없을 경우 empty list 반환
                 : fileService.storeFilesForPost(saved.getPostId(), files);
 
-        log.info("[NOTICE][POST][SAVE][END] 게시물 저장 완료 - postId={}, savedCount={}, fileCount={}",
+        log.info("[POST][SAVE][END] 게시물 저장 완료 - postId={}, savedCount={}, fileCount={}",
                 saved.getPostId(), savedMetas.size(), (files == null ? 0 : files.size()));
         return PostResponse.of(saved, savedMetas);
+    }
+
+    /**
+     * 게시글 수정 메서드
+     * <p>
+     * 게시글 ID와 수정 요청 정보를 받아 해당 게시글을 업데이트하고, 수정된 게시글 정보를 반환합니다.
+     * 내부적으로 게시글 존재 여부 확인, 권한 검증, 내용 변경 처리 등을 수행합니다.
+     *
+     * <ol>
+     *     <li>게시글 존재 여부 확인</li>
+     *     <li>사용자 권한 검증</li>
+     *     <li>게시글 내용 업데이트</li>
+     *     <li>변경 내용 저장 및 반환</li>
+     * </ol>
+     *
+     * @param memberId 수정 요청자의 ID (권한 검증용)
+     * @param postId 수정할 게시글의 ID
+     * @param request 게시글 수정 요청 DTO (제목, 내용 등 포함)
+     * @param files 첨부 파일 목록 (null 또는 빈 리스트일 수 있음)
+     *
+     * @throws ServiceException 게시글이 없거나 권한이 없을 경우 발생
+     */
+    @Override
+    @Transactional
+    public void updatePost(Long memberId, Long postId,
+                           PostUpdateRequest request, List<MultipartFile> files) {
+
+        log.info("[POST][UPDATE][START] 게시물 수정 시작 - postId={}, memberId={}", postId, memberId);
+
+        Post post = postRepository.findById(postId).orElseThrow(()
+                -> new ServiceException(ErrorCode.POST_NOT_FOUND));
+
+        post.validateMember(memberId); // 본인이 작성한 글인지 확인하기
+
+        post.update(request.getTitle(), request.getContent()); // 글 내용 업데이트 + 수정 시간 제공 + null 체크
+
+        Post saved = postRepository.save(post);// 업데이트된 게시글 저장
+
+        if (files != null && !files.isEmpty()) { // 첨부 파일이 있을 경우
+            fileService.deleteFilesForPost(postId); // 기존에 저장된 파일 삭제
+            fileService.storeFilesForPost(saved.getPostId(), files); // 파일이 같음을 확인할 수 없음... 그냥 업데이트
+        }
+
+        log.info("[POST][UPDATE][END] 게시물 수정 완료 - postId={}, memberId={}", postId, memberId);
     }
 }

--- a/src/main/java/com/grow/study_service/post/domain/model/Post.java
+++ b/src/main/java/com/grow/study_service/post/domain/model/Post.java
@@ -78,4 +78,56 @@ public class Post {
                 updatedAt
         );
     }
+
+    /**
+     * [게시글 소유자 검증 메서드]
+     * <p>
+     * 현재 게시글의 소유자가 입력된 memberId와 일치하는지 확인합니다.
+     * 필요한 경우 내부 처리 절차를 순서대로 기술할 수 있습니다.
+     *
+     * <ol>
+     *     <li>memberId 비교</li>
+     *     <li>불일치 시 예외 발생</li>
+     * </ol>
+     *
+     * @param memberId 검증할 회원 ID
+     *
+     * @throws DomainException 소유자가 아닐 경우
+     *
+     * @see ErrorCode#NOT_AUTHORIZED_USER
+     */
+    public void validateMember(Long memberId) {
+        if (this.memberId != memberId) {
+            throw new DomainException(ErrorCode.NOT_AUTHORIZED_USER);
+        }
+    }
+
+    /**
+     * [게시글 업데이트 메서드 (변경 여부 확인)]
+     * <p>
+     * 제목과 내용이 기존과 다른 경우에만 업데이트하며, 업데이트 시간을 설정합니다.
+     * 필요한 경우 내부 처리 절차를 순서대로 기술할 수 있습니다.
+     *
+     * <ol>
+     *     <li>제목 변경 확인</li>
+     *     <li>내용 변경 확인</li>
+     *     <li>업데이트 시간 설정</li>
+     * </ol>
+     *
+     * @param title 새로운 제목 (null 또는 빈 값 무시)
+     * @param content 새로운 내용 (null 또는 빈 값 무시)
+     *
+     * @implNote 변경 여부 확인으로 불필요한 업데이트 방지
+     */
+    public void update(String title, String content) {
+        if (!this.title.equals(title) && title != null && !title.isBlank()) {
+            this.title = title;
+        }
+
+        if (!this.content.equals(content) && content != null && !content.isBlank()) {
+            this.content = content;
+        }
+
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/grow/study_service/post/domain/repository/FileMetaRepository.java
+++ b/src/main/java/com/grow/study_service/post/domain/repository/FileMetaRepository.java
@@ -9,4 +9,6 @@ public interface FileMetaRepository {
     FileMeta save(FileMeta fileMeta);
     List<FileMeta> findAllByPostId(Long postId);
     Optional<FileMeta> findById(Long fileId);
+    List<FileMeta> findByPostId(Long postId);
+    void delete(FileMeta meta);
 }

--- a/src/main/java/com/grow/study_service/post/infra/persistence/repository/file/FileMetaJpaRepository.java
+++ b/src/main/java/com/grow/study_service/post/infra/persistence/repository/file/FileMetaJpaRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface FileMetaJpaRepository extends JpaRepository<FileMetaJpaEntity, Long> {
     List<FileMetaJpaEntity> findAllByPostId(Long postId);
+    List<FileMetaJpaEntity> findByPostId(Long postId);
 }

--- a/src/main/java/com/grow/study_service/post/infra/persistence/repository/file/FileMetaRepositoryImpl.java
+++ b/src/main/java/com/grow/study_service/post/infra/persistence/repository/file/FileMetaRepositoryImpl.java
@@ -41,4 +41,17 @@ public class FileMetaRepositoryImpl implements FileMetaRepository {
     public Optional<FileMeta> findById(Long fileId) {
         return jpaRepository.findById(fileId).map(mapper::toDomain);
     }
+
+    @Override
+    public List<FileMeta> findByPostId(Long postId) {
+        return jpaRepository.findByPostId(postId)
+                .stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void delete(FileMeta meta) {
+        jpaRepository.delete(mapper.toEntity(meta));
+    }
 }

--- a/src/main/java/com/grow/study_service/post/presentation/controller/PostController.java
+++ b/src/main/java/com/grow/study_service/post/presentation/controller/PostController.java
@@ -5,6 +5,7 @@ import com.grow.study_service.common.rsdata.RsData;
 import com.grow.study_service.post.application.find.PostFindService;
 import com.grow.study_service.post.application.save.PostSaveService;
 import com.grow.study_service.post.presentation.dto.request.PostSaveRequest;
+import com.grow.study_service.post.presentation.dto.request.PostUpdateRequest;
 import com.grow.study_service.post.presentation.dto.response.PostResponse;
 import com.grow.study_service.post.presentation.dto.response.PostSimpleResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -82,6 +83,19 @@ public class PostController {
     }
 
     // 글 수정을 위한 API
+    @PutMapping("/{postId}")
+    public RsData<Long> updatePost(@RequestHeader("X-Authorization-Id") Long memberId, // 본인 확인 용도
+                                     @PathVariable("postId") Long postId, // 업데이트 할 포스트 찾는 용도
+                                     @RequestPart("post") PostUpdateRequest request, // 업데이트 내용
+                                     @RequestPart(value = "files", required = false) List<MultipartFile> files) {
+
+        postSaveService.updatePost(memberId, postId, request, files);
+
+        return new RsData<>("200",
+                "글 수정 완료",
+                postId // ID 를 기반으로 라우팅
+        );
+    }
 
     // 글 삭제를 위한 API
 

--- a/src/main/java/com/grow/study_service/post/presentation/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/grow/study_service/post/presentation/dto/request/PostUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.grow.study_service.post.presentation.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostUpdateRequest {
+
+    @Size(max = 100, message = "제목은 최대 100자까지 가능합니다.")
+    private String title; // null 가능
+    private String content; // null 가능
+}

--- a/src/test/java/com/grow/study_service/post/application/find/PostSaveUpdatePostTest.java
+++ b/src/test/java/com/grow/study_service/post/application/find/PostSaveUpdatePostTest.java
@@ -50,9 +50,6 @@ public class PostSaveUpdatePostTest {
     @Autowired
     FileMetaRepository fileMetaRepository;
 
-    @TempDir // 임시 디렉토리 선택
-    Path tempDir;
-
     private Long seedPost(Long boardId, Long authorMemberId, String title, String content, List<MultipartFile> files) {
         PostSaveRequest req = new PostSaveRequest(boardId, title, content);
         PostResponse created = postSaveService.createPost(authorMemberId, req, files);

--- a/src/test/java/com/grow/study_service/post/application/find/PostSaveUpdatePostTest.java
+++ b/src/test/java/com/grow/study_service/post/application/find/PostSaveUpdatePostTest.java
@@ -1,0 +1,227 @@
+package com.grow.study_service.post.application.find;
+
+import com.grow.study_service.common.exception.ErrorCode;
+import com.grow.study_service.common.exception.domain.DomainException;
+import com.grow.study_service.common.exception.service.ServiceException;
+import com.grow.study_service.post.application.file.FileService;
+import com.grow.study_service.post.application.save.PostSaveService;
+import com.grow.study_service.post.domain.model.Post;
+import com.grow.study_service.post.domain.repository.FileMetaRepository;
+import com.grow.study_service.post.domain.repository.PostRepository;
+import com.grow.study_service.post.presentation.dto.request.PostSaveRequest;
+import com.grow.study_service.post.presentation.dto.request.PostUpdateRequest;
+import com.grow.study_service.post.presentation.dto.response.PostResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.transaction.annotation.Propagation.NOT_SUPPORTED;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+public class PostSaveUpdatePostTest {
+
+    @Autowired
+    private PostSaveService postSaveService;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @MockitoSpyBean(name="fileServiceImpl")
+    private FileService fileService;
+
+    @Autowired
+    FileMetaRepository fileMetaRepository;
+
+    @TempDir // 임시 디렉토리 선택
+    Path tempDir;
+
+    private Long seedPost(Long boardId, Long authorMemberId, String title, String content, List<MultipartFile> files) {
+        PostSaveRequest req = new PostSaveRequest(boardId, title, content);
+        PostResponse created = postSaveService.createPost(authorMemberId, req, files);
+        return created.getPostId();
+    }
+
+    private List<MultipartFile> mockFiles(String... names) {
+        return java.util.Arrays.stream(names)
+                .map(n -> new MockMultipartFile("files", n, "application/octet-stream", ("content-of-" + n).getBytes()))
+                .map(f -> (MultipartFile) f)
+                .toList();
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("제목/내용만 변경(파일 없음)")
+        void update_title_and_content_only() {
+            // given
+            Long authorId = 10L;
+            Long boardId = 100L;
+            Long postId = seedPost(boardId, authorId, "초기제목", "초기내용", List.of());
+
+            PostUpdateRequest req = new PostUpdateRequest("수정제목", "수정내용");
+
+            // when
+            postSaveService.updatePost(authorId, postId, req, null);
+
+            // then: DB에서 다시 로드하여 값 확인
+            Post updated = postRepository.findById(postId)
+                    .orElseThrow(() -> new IllegalStateException("post not found after update"));
+            assertThat(updated.getTitle()).isEqualTo("수정제목");
+            assertThat(updated.getContent()).isEqualTo("수정내용");
+            assertThat(updated.getUpdatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("파일 대체: 기존 파일 삭제 후 새 파일 저장")
+        void update_replace_files() {
+            // given
+            Long authorId = 11L;
+            Long boardId = 101L;
+            // 최초 생성 시 파일 2개
+            List<MultipartFile> initialFiles = mockFiles("a.txt", "b.txt");
+            Long postId = seedPost(boardId, authorId, "제목", "내용", initialFiles);
+
+            // 업데이트: 제목/내용 변경 + 파일 1개로 교체
+            PostUpdateRequest req = new PostUpdateRequest("새제목", "새내용");
+            List<MultipartFile> newFiles = mockFiles("c.txt");
+
+            // when
+            postSaveService.updatePost(authorId, postId, req, newFiles);
+
+            // then: DB 에서 다시 로드하여 값 확인
+            Post updated = postRepository.findById(postId)
+                    .orElseThrow();
+            assertThat(updated.getTitle()).isEqualTo("새제목");
+            assertThat(updated.getContent()).isEqualTo("새내용");
+
+            String originalName = fileMetaRepository.findByPostId(postId).get(0).getOriginalName();
+
+            assertThat(originalName).isEqualTo("c.txt");
+            assertThat(fileMetaRepository.findByPostId(postId)).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("제목만 변경(null 콘텐츠), 내용만 변경(null 제목)")
+        void update_partial_nulls() {
+            // given
+            Long authorId = 12L;
+            Long boardId = 102L;
+            Long postId = seedPost(boardId, authorId, "원제목", "원내용", List.of());
+
+            // when: 제목만 변경
+            postSaveService.updatePost(authorId, postId, new PostUpdateRequest("제목만", null), null);
+
+            // then
+            Post afterTitle = postRepository.findById(postId).orElseThrow();
+            assertThat(afterTitle.getTitle()).isEqualTo("제목만");
+            assertThat(afterTitle.getContent()).isEqualTo("원내용");
+
+            // when: 내용만 변경
+            postSaveService.updatePost(authorId, postId, new PostUpdateRequest(null, "내용만"), null);
+
+            // then
+            Post afterContent = postRepository.findById(postId).orElseThrow();
+            assertThat(afterContent.getTitle()).isEqualTo("제목만");
+            assertThat(afterContent.getContent()).isEqualTo("내용만");
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @Test
+        @DisplayName("존재하지 않는 게시글이면 예외")
+        void update_post_not_found() {
+            // given
+            Long authorId = 20L;
+            Long notExistPostId = 9_999_999L;
+            PostUpdateRequest req = new PostUpdateRequest("x", "y");
+
+            // when & then
+            assertThatThrownBy(() -> postSaveService.updatePost(authorId, notExistPostId, req, null))
+                    .isInstanceOf(ServiceException.class);
+        }
+
+        @Test
+        @DisplayName("작성자가 아니면 권한 예외")
+        void update_forbidden() {
+            // given
+            Long authorId = 21L;
+            Long otherMemberId = 22L;
+            Long boardId = 200L;
+            Long postId = seedPost(boardId, authorId, "t", "c", List.of());
+
+            // when & then
+            assertThatThrownBy(() -> postSaveService.updatePost(otherMemberId, postId, new PostUpdateRequest("변경", "변경"), null))
+                    .isInstanceOf(DomainException.class);
+        }
+
+        @Test
+        @Transactional(propagation = NOT_SUPPORTED)
+        @DisplayName("파일 서비스 오류 발생 시 롤백 보장 (delete 호출 여부 + DB 원복 + 파일 메타 원복까지 검증)")
+        void update_file_service_failure_causes_rollback() {
+            // given
+            Long authorId = 24L;
+            Long boardId = 202L;
+
+            // 최초 생성: 파일 1개 포함
+            List<MultipartFile> initialFiles = mockFiles("x.txt");
+            Long postId = seedPost(boardId, authorId, "before", "before", initialFiles);
+
+            // 사전 스냅샷
+            Post before = postRepository.findById(postId).orElseThrow();
+            assertThat(before.getTitle()).isEqualTo("before");
+            assertThat(before.getContent()).isEqualTo("before");
+            assertThat(fileMetaRepository.findByPostId(postId)).hasSize(1);
+            String beforeName = fileMetaRepository.findByPostId(postId).get(0).getOriginalName();
+            assertThat(beforeName).isEqualTo("x.txt");
+
+            // FileService 스텁: delete는 정상, store 에서 예외
+            Mockito.doNothing().when(fileService).deleteFilesForPost(eq(postId));
+            Mockito.doThrow(new ServiceException(ErrorCode.FILE_UPLOAD_FAILED))
+                    .when(fileService).storeFilesForPost(eq(postId), anyList());
+
+            assertThatThrownBy(() -> fileService.storeFilesForPost(postId, List.of())).isInstanceOf(ServiceException.class);
+
+            // when & then: 예외 발생
+            assertThatThrownBy(() ->
+                    postSaveService.updatePost(
+                            authorId,
+                            postId,
+                            new PostUpdateRequest("after", "after"),
+                            mockFiles("y.txt")
+                    )
+            ).isInstanceOf(ServiceException.class);
+
+            // 롤백 검증: 제목/내용/파일메타 원복
+            Post reloaded = postRepository.findById(postId).orElseThrow();
+            assertThat(reloaded.getTitle()).isEqualTo("before");
+            assertThat(reloaded.getContent()).isEqualTo("before");
+            assertThat(fileMetaRepository.findByPostId(postId)).hasSize(1);
+
+            String afterName = fileMetaRepository.findByPostId(postId).get(0).getOriginalName();
+            assertThat(afterName).isEqualTo("x.txt");
+        }
+    }
+}


### PR DESCRIPTION
## ✅ Check List(필수)
- [ ] 코드에 주석 추가 완료
- [ ] 테스트 통과 확인 (postman + h2 / test code)

+ 📸 Screenshot or Test Result

<img width="620" height="257" alt="스크린샷 2025-08-21 오후 9 58 27" src="https://github.com/user-attachments/assets/21661cd2-9312-46de-8dc1-d0127edccd1a" />

- 테스트 통과 완료

<img width="837" height="182" alt="스크린샷 2025-08-21 오후 9 07 07" src="https://github.com/user-attachments/assets/961e07e3-9642-4fc3-a67d-ff2f2cc9ba66" />

- 기존 저장 내역

<img width="799" height="328" alt="스크린샷 2025-08-21 오후 9 07 26" src="https://github.com/user-attachments/assets/bce360dd-35fe-4362-82de-141c51c2fdb6" />

- 제목만 수정했을 경우 (내용 수정 x)

<img width="1066" height="262" alt="스크린샷 2025-08-21 오후 9 09 18" src="https://github.com/user-attachments/assets/41aab38c-209b-4390-abab-43a9c10a69bf" />

- 파일을 추가했을 경우 
- 이전의 파일은 삭제되고 fileId 2 로 새로 생성됩니다
- 파일은 같은 파일이더라도 파일명을 바꿔서 올리면 결국 다른 파일로 인식하는 문제가 있어서... 그냥 무조건 삭제하고 다시 업데이트 하는 방식으로 진행했습니다 (파일 없이 업데이트 - 로직 진행하지 않음 / 파일이 이전에 없었는데 새로 추가하는 경우 - 삭제 없이 추가만 진행)

## 🔗 Related Issues(필수)
Closes #{이슈 번호}

## 📝 Note (주의 사항)
*리뷰어가 주의 깊게 봐야 하는 부분, 특이사항/고려할 점 기록*
"Redis 캐시 적용 필요" or "추후 프론트에서 토큰 연동"
