### PR TITLE
✨ feat: 스터디 그룹 조회 API 엔드포인트 구현 #33

### DIFF
--- a/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
+++ b/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     GROUP_ID_IS_EMPTY("400", "그룹 아이디는 비어있을 수 없습니다."),
     CATEGORY_IS_EMPTY("400", "카테고리는 비어있을 수 없습니다."),
     GROUP_LEADER_REQUIRED("403", "이 기능은 그룹장 권한이 있는 사용자만 사용할 수 있습니다. 그룹장 권한 요청 후 다시 시도해 주세요."),
+    GROUP_NOT_FOUND("404", "그룹을 찾을 수 없습니다." ),
 
     /**
      * 📌 2. 그룹 멤버(Group Member) 관련
@@ -70,7 +71,8 @@ public enum ErrorCode {
     INVALID_POST_ACCESS("403", "이 게시글에 접근할 권한이 없습니다. postId나 그룹 가입 상태를 확인해 주세요. "),
     COMMENT_ALREADY_EXISTS("409", "이미 동일한 댓글이 존재합니다. " ),
     COMMENT_NOT_FOUND("404", "댓글을 찾을 수 없습니다. "),
-    INVALID_COMMENT_ACCESS("403", "이 댓글에 접근할 권한이 없습니다. " ),;
+    INVALID_COMMENT_ACCESS("403", "이 댓글에 접근할 권한이 없습니다. " ),
+    ;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/grow/study_service/common/init/DataInit.java
+++ b/src/main/java/com/grow/study_service/common/init/DataInit.java
@@ -1,6 +1,11 @@
 package com.grow.study_service.common.init;
 
+import com.grow.study_service.board.domain.enums.BoardType;
+import com.grow.study_service.board.domain.model.Board;
+import com.grow.study_service.board.domain.repository.BoardRepository;
 import com.grow.study_service.group.domain.enums.Category;
+import com.grow.study_service.group.domain.enums.PersonalityTag;
+import com.grow.study_service.group.domain.enums.SkillTag;
 import com.grow.study_service.group.domain.model.Group;
 import com.grow.study_service.group.domain.repository.GroupRepository;
 import com.grow.study_service.groupmember.domain.enums.Role;
@@ -11,26 +16,62 @@ import com.grow.study_service.post.domain.repository.PostRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
-// @Component
+@Component
 @AllArgsConstructor
 public class DataInit implements CommandLineRunner {
 
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final PostRepository postRepository;
+    private final BoardRepository boardRepository;
 
     @Override
     public void run(String... args) throws Exception {
-        Group group1 = Group.create("test group 1", Category.STUDY, "test group 1 description");
-        groupRepository.save(group1);
+        List<Group> groups = new ArrayList<>();
+
+        // STUDY 카테고리: 7개
+        groups.add(Group.create("자바 프로그래밍 스터디", Category.STUDY, "자바 초보자들을 위한 실습 중심 스터디 그룹입니다.", PersonalityTag.DILIGENT, SkillTag.JAVA_PROGRAMMING, 0));
+        groups.add(Group.create("영어 회화 모임", Category.STUDY, "매일 영어 대화를 연습하며 실력을 키우는 학습 커뮤니티.", PersonalityTag.ACTIVE, SkillTag.ENGLISH_CONVERSATION, 0));
+        groups.add(Group.create("데이터 사이언스 학습단", Category.STUDY, "파이썬과 머신러닝을 함께 공부하는 열정적인 그룹.", PersonalityTag.CREATIVE, SkillTag.PYTHON_DATA_SCIENCE, 0));
+        groups.add(Group.create("역사 탐구 클럽", Category.STUDY, "고대 역사부터 현대사까지 깊이 있게 탐구합니다.", PersonalityTag.METICULOUS, SkillTag.HISTORY_EXPLORATION, 0));
+        groups.add(Group.create("수학 문제 풀이 그룹", Category.STUDY, "고등 수학 문제를 함께 풀며 논리력을 강화하세요.", PersonalityTag.ANALYTICAL, SkillTag.MATH_PROBLEM_SOLVING, 0));
+        groups.add(Group.create("프랑스어 배우기", Category.STUDY, "기초부터 고급까지 프랑스어를 재미있게 배우는 모임.", PersonalityTag.PATIENT, SkillTag.FRENCH_LANGUAGE, 0));
+        groups.add(Group.create("경제학 세미나", Category.STUDY, "경제 이론과 실생활 사례를 논의하는 지적 토론 그룹.", PersonalityTag.COLLABORATIVE, SkillTag.ECONOMICS, 0));
+
+        // HOBBY 카테고리: 7개
+        groups.add(Group.create("등산 동호회", Category.HOBBY, "주말마다 산을 오르며 자연을 즐기는 취미 모임.", PersonalityTag.ADVENTUROUS, SkillTag.HIKING, 0));
+        groups.add(Group.create("요리 마스터 클럽", Category.HOBBY, "다양한 요리 레시피를 공유하고 함께 만드는 재미있는 그룹.", PersonalityTag.CREATIVE, SkillTag.COOKING, 0));
+        groups.add(Group.create("기타 연주 모임", Category.HOBBY, "초보자부터 프로까지 기타를 치며 음악을 즐깁니다.", PersonalityTag.PASSIONATE, SkillTag.GUITAR_PLAYING, 0));
+        groups.add(Group.create("사진 촬영 여행단", Category.HOBBY, "카메라를 들고 여행하며 아름다운 순간을 담아요.", PersonalityTag.VIBRANT, SkillTag.PHOTOGRAPHY, 0));
+        groups.add(Group.create("독서 모임", Category.HOBBY, "매월 한 권의 책을 읽고 토론하는 문화 취미 그룹.", PersonalityTag.EMPATHETIC, SkillTag.BOOK_READING, 0));
+        groups.add(Group.create("원예 가드닝 클럽", Category.HOBBY, "집에서 식물을 키우며 여유로운 시간을 보내는 모임.", PersonalityTag.CALM, SkillTag.GARDENING, 0));
+        groups.add(Group.create("보드게임 파티", Category.HOBBY, "다양한 보드게임을 즐기며 친구를 사귀는 재미난 그룹.", PersonalityTag.HUMOROUS, SkillTag.BOARD_GAMES, 0));
+
+        // MENTORING 카테고리: 7개
+        groups.add(Group.create("커리어 멘토링 그룹", Category.MENTORING, "경력 개발을 위한 선배들의 조언을 공유하는 멘토링 모임.", PersonalityTag.SUPPORTIVE, SkillTag.CAREER_COACHING, 10000));
+        groups.add(Group.create("스타트업 창업 가이드", Category.MENTORING, "창업 아이디어를 실현하기 위한 실전 멘토링 세션.", PersonalityTag.INNOVATIVE, SkillTag.STARTUP_GUIDANCE, 20000));
+        groups.add(Group.create("리더십 코칭 클럽", Category.MENTORING, "리더십 스킬을 키우는 개인화된 멘토링 프로그램.", PersonalityTag.CHARISMATIC, SkillTag.LEADERSHIP_COACHING, 80000));
+        groups.add(Group.create("IT 취업 준비단", Category.MENTORING, "IT 분야 취업을 위한 이력서 작성과 인터뷰 팁 공유.", PersonalityTag.DISCIPLINED, SkillTag.IT_JOB_PREPARATION, 120000));
+        groups.add(Group.create("예술가 멘토링 네트워크", Category.MENTORING, "예술 창작자들을 위한 영감과 피드백 멘토링.", PersonalityTag.INSPIRING, SkillTag.ART_MENTORING, 30000));
+        groups.add(Group.create("금융 투자 조언 모임", Category.MENTORING, "투자 초보자를 위한 전문가 멘토링 그룹.", PersonalityTag.ANALYTICAL, SkillTag.FINANCIAL_INVESTMENT, 40000));
+        groups.add(Group.create("건강 관리 코칭", Category.MENTORING, "건강한 생활 습관을 위한 개인 멘토링과 조언.", PersonalityTag.RESILIENT, SkillTag.HEALTH_COACHING, 50000));
+
+        groups.forEach(groupRepository::save);
 
         GroupMember groupMember = GroupMember.create(1L, 1L, Role.MEMBER);
         GroupMember groupLeader = GroupMember.create(2L, 1L, Role.LEADER);
 
         groupMemberRepository.save(groupMember);
         groupMemberRepository.save(groupLeader);
+
+        Board board1 = Board.create(1L, BoardType.ASSIGNMENT_SUBMISSION, "test board 1", "test board 1 description");
+        boardRepository.save(board1);
 
         Post post1 = Post.create(1L, 1L, "첫 번째 게시글 제목", "첫 번째 게시글 내용");
         Post post2 = Post.create(1L, 2L, "두 번째 게시글 제목", "두 번째 게시글 내용");

--- a/src/main/java/com/grow/study_service/group/application/GroupService.java
+++ b/src/main/java/com/grow/study_service/group/application/GroupService.java
@@ -1,0 +1,12 @@
+package com.grow.study_service.group.application;
+
+import com.grow.study_service.group.domain.enums.Category;
+import com.grow.study_service.group.presentation.dto.GroupDetailResponse;
+import com.grow.study_service.group.presentation.dto.GroupResponse;
+
+import java.util.List;
+
+public interface GroupService {
+    List<GroupResponse> getAllGroupsByCategory(Category category);
+    GroupDetailResponse getGroup(Long groupId);
+}

--- a/src/main/java/com/grow/study_service/group/application/GroupServiceImpl.java
+++ b/src/main/java/com/grow/study_service/group/application/GroupServiceImpl.java
@@ -1,0 +1,82 @@
+package com.grow.study_service.group.application;
+
+import com.grow.study_service.common.exception.ErrorCode;
+import com.grow.study_service.common.exception.service.ServiceException;
+import com.grow.study_service.group.domain.enums.Category;
+import com.grow.study_service.group.domain.model.Group;
+import com.grow.study_service.group.domain.repository.GroupRepository;
+import com.grow.study_service.group.presentation.dto.GroupDetailResponse;
+import com.grow.study_service.group.presentation.dto.GroupResponse;
+import com.grow.study_service.groupmember.domain.repository.GroupMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroupServiceImpl implements GroupService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    /**
+     * 주어진 카테고리에 속한 모든 그룹을 조회하여 GroupResponse 리스트로 반환합니다.
+     *
+     * 이 메서드는 데이터베이스에서 지정된 카테고리의 그룹 목록을 가져온 후,
+     * 이를 GroupResponse DTO로 변환합니다. 조회 과정은 읽기 전용 트랜잭션으로 실행되며,
+     * 로그를 통해 조회 시작과 종료를 기록합니다.
+     *
+     * @param category 조회할 그룹의 카테고리 (예: STUDY, HOBBY, MENTORING). null이 아니어야 합니다.
+     * @return 지정된 카테고리의 그룹 정보를 담은 GroupResponse 리스트. 그룹이 없을 경우 빈 리스트를 반환합니다.
+     * @since 1.0
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<GroupResponse> getAllGroupsByCategory(Category category) {
+        log.info("[GROUP][SEARCH][START] 전체 {} 그룹 조회 시작", category.getDescription());
+
+        List<Group> groupList = groupRepository.findAllByCategory(category);
+
+        List<GroupResponse> list = groupList.stream()
+                .map(GroupResponse::of)
+                .collect(Collectors.toList());
+
+        log.info("[GROUP][SEARCH][END] 전체 {} 그룹 조회 완료={} 건", category.getDescription(), list.size());
+        return list;
+    }
+
+    /**
+     * 주어진 그룹 ID에 해당하는 그룹의 상세 정보를 조회하여 GroupDetailResponse로 반환합니다.
+     *
+     * 이 메서드는 데이터베이스에서 그룹을 조회한 후, 조회수를 1 증가시키고 업데이트합니다.
+     * 동시에 해당 그룹의 멤버 수를 계산하여 응답에 포함합니다. 전체 과정은 트랜잭션으로 관리되며,
+     * 그룹이 존재하지 않을 경우 ServiceException을 발생시킵니다. 로그를 통해 조회 시작과 종료를 기록합니다.
+     *
+     * @param groupId 조회할 그룹의 고유 ID. null이 아니어야 하며, 양의 정수여야 합니다.
+     * @return 그룹 상세 정보와 멤버 수를 담은 GroupDetailResponse 객체.
+     * @throws ServiceException 그룹이 존재하지 않을 경우 (ErrorCode.GROUP_NOT_FOUND) 발생.
+     */
+    @Override
+    @Transactional
+    public GroupDetailResponse getGroup(Long groupId) {
+        log.info("[GROUP][DETAIL][START] 그룹 상세 조회 시작 groupId={}", groupId);
+
+        Group group = groupRepository.findById(groupId).orElseThrow(() ->
+                new ServiceException(ErrorCode.GROUP_NOT_FOUND));
+
+        Group updated = group.incrementViewCount();// 조회수 증가
+
+        groupRepository.save(updated); // 조회수 업데이트
+
+        int memberCount = groupMemberRepository.findMemberCountByGroupId(groupId); // 이것도 그룹의 필드로 저장할까 고민 중입니다... 흠
+
+        log.info("[GROUP][DETAIL][END] 그룹 상세 조회 완료 groupId={} memberCount={}", groupId, memberCount);
+
+        return GroupDetailResponse.of(group, memberCount);
+    }
+}

--- a/src/main/java/com/grow/study_service/group/domain/enums/Category.java
+++ b/src/main/java/com/grow/study_service/group/domain/enums/Category.java
@@ -1,5 +1,14 @@
 package com.grow.study_service.group.domain.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum Category {
-	STUDY, HOBBY, MENTORING
+	STUDY("스터디"),
+	HOBBY("취미"),
+	MENTORING("멘토링");
+
+	private final String description;
 }

--- a/src/main/java/com/grow/study_service/group/domain/enums/PersonalityTag.java
+++ b/src/main/java/com/grow/study_service/group/domain/enums/PersonalityTag.java
@@ -1,0 +1,40 @@
+package com.grow.study_service.group.domain.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * PersonalityTag: 성격/특성 관련 태그 (그룹의 분위기나 멤버 성향을 나타냄)
+ */
+@Getter
+@AllArgsConstructor
+public enum PersonalityTag {
+
+    DILIGENT("성실한"),          // 꾸준하고 책임감 있음
+    ACTIVE("활발한"),            // 에너지 넘치고 활동적
+    CREATIVE("창의적인"),        // 아이디어 풍부하고 혁신적
+    COLLABORATIVE("협력적인"),   // 팀워크를 중시함
+    PASSIONATE("열정적인"),      // 열의가 넘침
+    METICULOUS("꼼꼼한"),        // 세밀하고 정확함
+    HUMOROUS("유머러스한"),      // 재미있고 밝음
+    PROGRESSIVE("진취적인"),     // 앞으로 나아가는 성향
+    PATIENT("인내심 있는"),     // 참을성 있음
+    OPTIMISTIC("낙관적인"),      // 긍정적 사고
+    ADVENTUROUS("모험적인"),     // 도전적이고 탐험 좋아함
+    EMPATHETIC("공감하는"),      // 타인 감정을 잘 이해함
+    DISCIPLINED("규율 있는"),   // 자기 관리 능력 강함
+    INNOVATIVE("혁신적인"),      // 새로운 아이디어 창출
+    RESILIENT("회복력 있는"),   // 어려움에서 잘 회복함
+    CHARISMATIC("카리스마 있는"), // 매력적이고 리더십 있음
+    MODEST("겸손한"),            // 자신을 과시하지 않음
+    ANALYTICAL("분석적인"),      // 논리적 사고 강함
+    ENTHUSIASTIC("열광적인"),    // 모든 일에 열정적
+    SUPPORTIVE("지지하는"),      // 타인을 돕는 성향
+    VERSATILE("다재다능한"),     // 여러 분야에 능함
+    CALM("침착한"),              // 위기 시 안정적
+    INSPIRING("영감을 주는"),   // 타인에게 동기부여
+    LOYAL("충성스러운"),         // 관계를 소중히 함
+    VIBRANT("생기 넘치는");      // 활기차고 에너지 충만
+
+    private final String description;
+}

--- a/src/main/java/com/grow/study_service/group/domain/enums/SkillTag.java
+++ b/src/main/java/com/grow/study_service/group/domain/enums/SkillTag.java
@@ -1,0 +1,67 @@
+package com.grow.study_service.group.domain.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * SkillTag: 기술/스킬 관련 태그 (카테고리별로 STUDY, HOBBY, MENTORING에 맞춤)
+ * STUDY: 학습 중심, HOBBY: 취미 중심, MENTORING: 멘토링 중심으로 다양하게 추가
+ */
+@Getter
+@AllArgsConstructor
+public enum SkillTag {
+
+    // STUDY 관련 (학습/지식 스킬)
+    JAVA_PROGRAMMING("자바 프로그래밍"),
+    PYTHON_DATA_SCIENCE("파이썬 데이터 사이언스"),
+    ENGLISH_CONVERSATION("영어 회화"),
+    MATH_PROBLEM_SOLVING("수학 문제 풀이"),
+    HISTORY_EXPLORATION("역사 탐구"),
+    FRENCH_LANGUAGE("프랑스어 학습"),
+    ECONOMICS("경제"),
+    AI_MACHINE_LEARNING("AI/머신러닝"),
+    WEB_DEVELOPMENT("웹 개발"),
+    DATABASE_MANAGEMENT("데이터베이스 관리"),
+    TOEIC("토익 자격증"),
+
+    // HOBBY 관련 (취미/여가 스킬)
+    HIKING("등산"),
+    COOKING("요리"),
+    GUITAR_PLAYING("기타 연주"),
+    PHOTOGRAPHY("사진 촬영"),
+    BOOK_READING("독서"),
+    GARDENING("원예"),
+    BOARD_GAMES("보드게임"),
+    PAINTING("회화"),
+    YOGA("요가"),
+    DANCING("댄스"),
+    FISHING("낚시"),
+    CYCLING("자전거 타기"),
+    KNITTING("뜨개질"),
+    TRAVEL_PLANNING("여행 계획"),
+    MOVIE_APPRECIATION("영화 감상"),
+
+    // MENTORING 관련 (전문/코칭 스킬)
+    CAREER_COACHING("커리어 멘토링"),
+    STARTUP_GUIDANCE("스타트업 창업 가이드"),
+    LEADERSHIP_COACHING("리더십 코칭"),
+    IT_JOB_PREPARATION("IT 취업 준비"),
+    ART_MENTORING("예술가 멘토링"),
+    FINANCIAL_INVESTMENT("금융 투자 조언"),
+    HEALTH_COACHING("건강 관리 코칭"),
+    PUBLIC_SPEAKING("공개 연설"),
+    PROJECT_MANAGEMENT("프로젝트 관리"),
+    MARKETING_STRATEGY("마케팅 전략"),
+    NEGOTIATION_SKILLS("협상 기술"),
+    TIME_MANAGEMENT("시간 관리"),
+    CREATIVE_WRITING("창의적 글쓰기"),
+    NETWORKING("네트워킹"),
+    EMOTIONAL_INTELLIGENCE("감성 지능"),
+    BACKEND_DEVELOPMENT("백엔드 개발"),  // 쿼리 예시 포함
+    FRONTEND_DEVELOPMENT("프론트엔드 개발"),
+    MOBILE_APP_DEVELOPMENT("모바일 앱 개발"),
+    GRAPHIC_DESIGN("그래픽 디자인"),
+    CONTENT_CREATION("콘텐츠 제작");
+
+    private final String description;
+}

--- a/src/main/java/com/grow/study_service/group/domain/model/Group.java
+++ b/src/main/java/com/grow/study_service/group/domain/model/Group.java
@@ -2,6 +2,8 @@ package com.grow.study_service.group.domain.model;
 
 import com.grow.study_service.common.exception.domain.DomainException;
 import com.grow.study_service.common.exception.ErrorCode;
+import com.grow.study_service.group.domain.enums.PersonalityTag;
+import com.grow.study_service.group.domain.enums.SkillTag;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -48,6 +50,30 @@ public class Group {
     private String description;
 
     /**
+     * 멘토링 시, 가격 설정 값.
+     */
+    private int amount;
+
+    /**
+     * 그룹의 조회수. (인기순으로 필터링할 때 사용)
+     */
+    private int viewCount;
+
+    /**
+     * 그룹의 성격/특성 관련 태그.
+     */
+    private PersonalityTag personalityTag;
+
+    /**
+     * 기술/스킬 관련 태그.
+     */
+    private SkillTag skillTag;
+
+    // TODO 기간 추가
+
+    private Long version; // 낙관적 락
+
+    /**
      * 새로운 그룹을 생성하는 팩토리 메서드.
      * 그룹 ID는 null로 설정되며, 데이터베이스 삽입 시 자동 생성됩니다.
      *
@@ -59,15 +85,23 @@ public class Group {
      */
     public static Group create(String name,
                                Category category,
-                               String description) {
+                               String description,
+                               PersonalityTag personalityTag,
+                               SkillTag skillTag,
+                               int amount) {
 
         verifyParameters(name, category, description);
         return new Group(
-                null,
+                null, // 자동 생성
                 category,
-                LocalDateTime.now(), // 데이터베이스에 저장될 때는 현재 시각을 사용함. (자동 생성)
+                LocalDateTime.now(), // 데이터베이스에 저장될 때는 현재 시각을 사용함.
                 description,
-                name
+                name,
+                amount,
+                0,
+                personalityTag, // null 가능
+                skillTag, // null 가능
+                null // 자동 생성
         );
     }
 
@@ -98,9 +132,19 @@ public class Group {
                            String name,
                            Category category,
                            String description,
-                           LocalDateTime createdAt) {
+                           LocalDateTime createdAt,
+                           int amount,
+                           int viewCount,
+                           PersonalityTag personalityTag,
+                           SkillTag skillTag,
+                           Long version) {
 
-        return new Group(groupId, category, createdAt, name, description);
+        return new Group(
+                groupId, category,
+                createdAt, name,
+                description, amount,
+                viewCount, personalityTag,
+                skillTag, version);
     }
 
     // ==== 업데이트 로직 ==== //
@@ -136,5 +180,11 @@ public class Group {
         if (!this.description.equals(newDescription)) {
             this.description = newDescription;
         }
+    }
+
+    public Group incrementViewCount() {
+        this.viewCount++;
+
+        return this;
     }
 }

--- a/src/main/java/com/grow/study_service/group/domain/repository/GroupRepository.java
+++ b/src/main/java/com/grow/study_service/group/domain/repository/GroupRepository.java
@@ -1,11 +1,14 @@
 package com.grow.study_service.group.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import com.grow.study_service.group.domain.enums.Category;
 import com.grow.study_service.group.domain.model.Group;
 
 public interface GroupRepository {
 	Group save(Group group);
 	Optional<Group> findById(Long groupId);
 	void delete(Group group);
+    List<Group> findAllByCategory(Category category);
 }

--- a/src/main/java/com/grow/study_service/group/infra/persistence/entity/GroupJpaEntity.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/entity/GroupJpaEntity.java
@@ -4,14 +4,9 @@ import java.time.LocalDateTime;
 
 import com.grow.study_service.group.domain.enums.Category;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import com.grow.study_service.group.domain.enums.PersonalityTag;
+import com.grow.study_service.group.domain.enums.SkillTag;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -21,6 +16,7 @@ import lombok.*;
 @AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class GroupJpaEntity {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -34,4 +30,17 @@ public class GroupJpaEntity {
 	private String description;
 
 	private LocalDateTime createdAt;
+
+	private int amount; // 멘토링 설정 값 (다른 항목에선 0 유지)
+
+	private int viewCount; // 조회수
+
+	@Enumerated(EnumType.STRING)
+	private PersonalityTag personalityTag;
+
+	@Enumerated(EnumType.STRING)
+	private SkillTag skillTag;
+
+	@Version
+	private Long version; // 낙관적 락
 }

--- a/src/main/java/com/grow/study_service/group/infra/persistence/mapper/GroupMapper.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/mapper/GroupMapper.java
@@ -29,7 +29,12 @@ public class GroupMapper {
 				entity.getName(),
 				entity.getCategory(),
 				entity.getDescription(),
-				entity.getCreatedAt()
+				entity.getCreatedAt(),
+				entity.getAmount(),
+				entity.getViewCount(),
+				entity.getPersonalityTag(),
+				entity.getSkillTag(),
+				entity.getVersion()
 		);
 	}
 
@@ -46,7 +51,12 @@ public class GroupMapper {
 				.name(group.getName())
 				.category(group.getCategory())
 				.description(group.getDescription())
-				.createdAt(group.getCreatedAt());
+				.createdAt(group.getCreatedAt())
+				.amount(group.getAmount())
+				.personalityTag(group.getPersonalityTag())
+				.viewCount(group.getViewCount())
+				.version(group.getVersion())
+				.skillTag(group.getSkillTag());
 
 		if (group.getGroupId() != null) {
 			builder.id(group.getGroupId());

--- a/src/main/java/com/grow/study_service/group/infra/persistence/repository/GroupJpaRepository.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/repository/GroupJpaRepository.java
@@ -1,9 +1,13 @@
 package com.grow.study_service.group.infra.persistence.repository;
 
+import com.grow.study_service.group.domain.enums.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.grow.study_service.group.infra.persistence.entity.GroupJpaEntity;
 
+import java.util.List;
+
 public interface GroupJpaRepository
 	extends JpaRepository<GroupJpaEntity, Long> {
+    List<GroupJpaEntity> findAllByCategory(Category category);
 }

--- a/src/main/java/com/grow/study_service/group/infra/persistence/repository/GroupRepositoryImpl.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/repository/GroupRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.grow.study_service.group.infra.persistence.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import com.grow.study_service.group.domain.enums.Category;
 import org.springframework.stereotype.Repository;
 
 import com.grow.study_service.group.domain.model.Group;
@@ -29,5 +31,14 @@ public class GroupRepositoryImpl implements GroupRepository {
 	@Override
 	public void delete(Group group) {
 		groupJpaRepository.delete(GroupMapper.toEntity(group));
+	}
+
+	// 카테고리별 전체 그룹을 조회
+	@Override
+	public List<Group> findAllByCategory(Category category) {
+        return groupJpaRepository.findAllByCategory(category)
+				.stream()
+				.map(GroupMapper::toDomain)
+				.toList();
 	}
 }

--- a/src/main/java/com/grow/study_service/group/presentation/controller/GroupFindController.java
+++ b/src/main/java/com/grow/study_service/group/presentation/controller/GroupFindController.java
@@ -1,0 +1,45 @@
+package com.grow.study_service.group.presentation.controller;
+
+import com.grow.study_service.common.rsdata.RsData;
+import com.grow.study_service.group.application.GroupService;
+import com.grow.study_service.group.domain.enums.Category;
+import com.grow.study_service.group.presentation.dto.GroupDetailResponse;
+import com.grow.study_service.group.presentation.dto.GroupResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/groups")
+public class GroupFindController {
+
+    private final GroupService groupService;
+
+    // 전체 그룹 조회 (카테고리 별 조회 가능)
+    @GetMapping("/{category}")
+    public RsData<List<GroupResponse>> getGroups(@PathVariable("category") Category category) {
+
+        List<GroupResponse> responses = groupService.getAllGroupsByCategory(category);
+
+        return new RsData<>(
+                "200",
+                "그룹 조회 완료",
+                responses
+        );
+    }
+
+    // 특정 그룹 조회 (ID)
+    @GetMapping("/{category}/{groupId}")
+    public RsData<GroupDetailResponse> getSingleGroup(@PathVariable("category") Category category,
+                                                      @PathVariable("groupId") Long groupId) {
+        GroupDetailResponse response = groupService.getGroup(groupId);
+
+        return new RsData<>(
+                "200",
+                "특정 그룹 조회 완료",
+                response
+        );
+    }
+}

--- a/src/main/java/com/grow/study_service/group/presentation/dto/GroupDetailResponse.java
+++ b/src/main/java/com/grow/study_service/group/presentation/dto/GroupDetailResponse.java
@@ -1,0 +1,37 @@
+package com.grow.study_service.group.presentation.dto;
+
+import com.grow.study_service.group.domain.enums.Category;
+import com.grow.study_service.group.domain.enums.PersonalityTag;
+import com.grow.study_service.group.domain.enums.SkillTag;
+import com.grow.study_service.group.domain.model.Group;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GroupDetailResponse {
+
+    private Long groupId;
+    private String groupName;
+    private Category category;
+    private String description;
+    private int amount;
+    private int viewCount;
+    private int memberCount;
+    private PersonalityTag personalityTag;
+    private SkillTag skillTag;
+
+    public static GroupDetailResponse of(Group group, int memberCount) {
+        return GroupDetailResponse.builder()
+                .groupId(group.getGroupId())
+                .groupName(group.getName())
+                .category(group.getCategory())
+                .description(group.getDescription())
+                .amount(group.getAmount())
+                .viewCount(group.getViewCount())
+                .memberCount(memberCount)
+                .personalityTag(group.getPersonalityTag())
+                .skillTag(group.getSkillTag())
+                .build();
+    }
+}

--- a/src/main/java/com/grow/study_service/group/presentation/dto/GroupResponse.java
+++ b/src/main/java/com/grow/study_service/group/presentation/dto/GroupResponse.java
@@ -1,0 +1,36 @@
+package com.grow.study_service.group.presentation.dto;
+
+import com.grow.study_service.group.domain.enums.Category;
+import com.grow.study_service.group.domain.enums.PersonalityTag;
+import com.grow.study_service.group.domain.enums.SkillTag;
+import com.grow.study_service.group.domain.model.Group;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+// TODO 그룹장의 이름을 같이 넘길 것
+@Getter
+@Builder
+@AllArgsConstructor
+public class GroupResponse {
+
+    private Long groupId;
+    private String groupName;
+    private Category category;
+    private String description;
+    private int amount;
+    private PersonalityTag personalityTag;
+    private SkillTag skillTag;
+
+    public static GroupResponse of(Group group) {
+        return GroupResponse.builder()
+                .groupId(group.getGroupId())
+                .groupName(group.getName())
+                .category(group.getCategory())
+                .amount(group.getAmount())
+                .description(group.getDescription())
+                .personalityTag(group.getPersonalityTag())
+                .skillTag(group.getSkillTag())
+                .build();
+    }
+}

--- a/src/main/java/com/grow/study_service/groupmember/domain/repository/GroupMemberRepository.java
+++ b/src/main/java/com/grow/study_service/groupmember/domain/repository/GroupMemberRepository.java
@@ -11,4 +11,5 @@ public interface GroupMemberRepository {
 	Optional<GroupMember> findGroupMemberByMemberIdAndGroupId(Long memberId, Long groupId);
 	boolean existsByGroupIdAndMemberId(Long groupId, Long memberId);
 	boolean existsByMemberIdAndPostGroup(Long postId, Long memberId);
+    int findMemberCountByGroupId(Long groupId);
 }

--- a/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberJpaRepository.java
+++ b/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberJpaRepository.java
@@ -32,4 +32,5 @@ public interface GroupMemberJpaRepository
 	boolean existsByMemberIdAndPostGroup(@Param("postId") Long postId,
 										 @Param("memberId") Long memberId);
 
+    long countByGroupId(Long groupId);
 }

--- a/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberRepositoryImpl.java
+++ b/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberRepositoryImpl.java
@@ -1,8 +1,6 @@
 package com.grow.study_service.groupmember.infra.persistence.repository;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 
@@ -73,5 +71,10 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepository {
 	@Override
 	public boolean existsByMemberIdAndPostGroup(Long postId, Long memberId) {
 		return groupMemberJpaRepository.existsByMemberIdAndPostGroup(postId, memberId);
+	}
+
+	@Override
+	public int findMemberCountByGroupId(Long groupId) {
+		return (int) groupMemberJpaRepository.countByGroupId(groupId);
 	}
 }


### PR DESCRIPTION
## ✅ Check List(필수)
- [X] 코드에 주석 추가 완료
- [X] 테스트 통과 확인 (postman + front 연동)
- [X] 문서 업데이트 완료 (아직 안 했는데 이거 하겠습니다... 까먹음 ㅎㅎ;)

+ 📸 Screenshot or Test Result

<img width="1008" height="672" alt="스크린샷 2025-08-28 오후 9 35 57" src="https://github.com/user-attachments/assets/7abb48f1-a19f-43f4-ac4c-ef2bffb9ec0c" />
<img width="964" height="650" alt="스크린샷 2025-08-28 오후 9 36 06" src="https://github.com/user-attachments/assets/1f325d13-c47b-44d1-aa4c-7d2b90ff5ee5" />

- 조회 시 뷰 카운트 증가 확인

<img width="977" height="769" alt="스크린샷 2025-08-28 오후 9 44 58" src="https://github.com/user-attachments/assets/f7231ffa-9c6f-4670-ab19-0b2b2dcad87f" />

- 전체 그룹 조회 확인 

## 📝 Note (주의 사항)
추가 구현이 필요한 부분은 TODO 로 달아두었습니다 해당 내용도 추가해서 내일 PR 올려둘게요! 
1. 낙관적 락을 적용하여 viewCount 는 동시성 위험에서 배제되었습니다
2. 그룹 조회 컨트롤러 자체는 회원이 아닌 사람들도 조회는 할 수 있어야 할 것 같아 memberId를 인수로 받지 않습니다 
3. 추후에 겸사겸사 페이징도 해서 넘겨야겠죠... 정말 저는 페이징이 싫네요 
