### PR TITLE
✨ feat: 멘토링 그룹에 가입 / 스터디 or 취미 그룹에 가입 요청을 전송하는 API 생성 + 현재 가입 그룹을 조회하는 API 생성 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,12 @@ dependencies {
 
 	// WebClient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/grow/study_service/common/config/QuerydslConfig.java
+++ b/src/main/java/com/grow/study_service/common/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.grow.study_service.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
+++ b/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     CATEGORY_IS_EMPTY("400", "카테고리는 비어있을 수 없습니다."),
     GROUP_LEADER_REQUIRED("403", "이 기능은 그룹장 권한이 있는 사용자만 사용할 수 있습니다. 그룹장 권한 요청 후 다시 시도해 주세요."),
     GROUP_NOT_FOUND("404", "그룹을 찾을 수 없습니다." ),
+    GROUP_ALREADY_JOINED("409", "이미 가입된 그룹입니다."),
+    JOIN_REQUEST_ALREADY_SENT("409", "이미 가입 요청을 보냈습니다." ),
 
     /**
      * 📌 2. 그룹 멤버(Group Member) 관련
@@ -28,6 +30,7 @@ public enum ErrorCode {
     GROUP_MEMBER_NOT_FOUND("404", "그룹 멤버를 찾을 수 없습니다."),
     MEMBER_NOT_IN_GROUP("403", "그룹 멤버가 아닙니다. 접근 권한이 없습니다."),
     GROUP_OR_LEADER_NOT_FOUND("404", "그룹 또는 그룹의 리더를 찾을 수 없습니다. " ),
+
 
     /**
      * 📌 3. 게시판(Board) 관련
@@ -70,9 +73,9 @@ public enum ErrorCode {
      */
     COMMENT_CONTENT_IS_EMPTY("400", "댓글 내용은 비어있을 수 없습니다."),
     INVALID_POST_ACCESS("403", "이 게시글에 접근할 권한이 없습니다. postId나 그룹 가입 상태를 확인해 주세요. "),
-    COMMENT_ALREADY_EXISTS("409", "이미 동일한 댓글이 존재합니다. " ),
-    COMMENT_NOT_FOUND("404", "댓글을 찾을 수 없습니다. "),
-    INVALID_COMMENT_ACCESS("403", "이 댓글에 접근할 권한이 없습니다. " ),
+    COMMENT_ALREADY_EXISTS("409", "이미 동일한 댓글이 존재합니다." ),
+    COMMENT_NOT_FOUND("404", "댓글을 찾을 수 없습니다."),
+    INVALID_COMMENT_ACCESS("403", "이 댓글에 접근할 권한이 없습니다." ),
     ;
 
     private final String code;

--- a/src/main/java/com/grow/study_service/common/init/DataInit.java
+++ b/src/main/java/com/grow/study_service/common/init/DataInit.java
@@ -119,6 +119,10 @@ public class DataInit implements CommandLineRunner {
         groupMembers.add(GroupMember.create(41L, 21L, Role.LEADER)); // 건강 관리 코칭 리더
         groupMembers.add(GroupMember.create(42L, 21L, Role.MEMBER)); // 건강 관리 코칭 멤버
 
+        // 여러 그룹에 가입한 회원 추가
+        groupMembers.add(GroupMember.create(1L, 2L, Role.MEMBER)); // 영어 회화 모임 멤버로 가입
+        groupMembers.add(GroupMember.create(1L, 3L, Role.MEMBER)); // 데이터 사이언스 학습단 멤버로 가입
+
         // 모든 GroupMember 저장
         groupMembers.forEach(groupMemberRepository::save);
 

--- a/src/main/java/com/grow/study_service/group/application/GroupTransactionService.java
+++ b/src/main/java/com/grow/study_service/group/application/GroupTransactionService.java
@@ -5,6 +5,7 @@ import com.grow.study_service.group.application.dto.GroupWithLeader;
 import com.grow.study_service.group.domain.enums.Category;
 import com.grow.study_service.group.presentation.dto.GroupDetailResponse;
 import com.grow.study_service.group.presentation.dto.GroupResponse;
+import com.grow.study_service.group.presentation.dto.GroupSimpleResponse;
 
 import java.util.List;
 
@@ -16,4 +17,6 @@ public interface GroupTransactionService {
     GroupDetailPrep prepareGroupDetail(Long groupId);
 
     GroupDetailResponse buildGroupDetailResponse(GroupDetailPrep prep, String leaderName, Long groupId);
+
+    List<GroupSimpleResponse> getMyGroupsByCategory(Category category, Long memberId);
 }

--- a/src/main/java/com/grow/study_service/group/application/GroupTransactionServiceImpl.java
+++ b/src/main/java/com/grow/study_service/group/application/GroupTransactionServiceImpl.java
@@ -7,8 +7,10 @@ import com.grow.study_service.group.application.dto.GroupWithLeader;
 import com.grow.study_service.group.domain.enums.Category;
 import com.grow.study_service.group.domain.model.Group;
 import com.grow.study_service.group.domain.repository.GroupRepository;
+import com.grow.study_service.group.infra.persistence.repository.query.GroupQueryRepository;
 import com.grow.study_service.group.presentation.dto.GroupDetailResponse;
 import com.grow.study_service.group.presentation.dto.GroupResponse;
+import com.grow.study_service.group.presentation.dto.GroupSimpleResponse;
 import com.grow.study_service.groupmember.domain.model.GroupMember;
 import com.grow.study_service.groupmember.domain.repository.GroupMemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ public class GroupTransactionServiceImpl implements GroupTransactionService {
 
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final GroupQueryRepository groupQueryRepository;
 
     /**
      * 주어진 카테고리에 해당하는 모든 그룹과 각각의 그룹 리더 정보를 조회하여
@@ -151,5 +154,12 @@ public class GroupTransactionServiceImpl implements GroupTransactionService {
         log.info("[GROUP][DETAIL][END] 그룹 상세 조회 완료 groupId={} memberCount={}", groupId, memberCount);
 
         return GroupDetailResponse.of(group, memberCount, leaderName);
+    }
+
+    // 빈 리스트 반환 가능
+    @Override
+    @Transactional(readOnly = true)
+    public List<GroupSimpleResponse> getMyGroupsByCategory(Category category, Long memberId) {
+        return groupQueryRepository.findJoinedGroupsByMemberAndCategory(memberId, category);
     }
 }

--- a/src/main/java/com/grow/study_service/group/application/join/GroupJoinService.java
+++ b/src/main/java/com/grow/study_service/group/application/join/GroupJoinService.java
@@ -1,0 +1,8 @@
+package com.grow.study_service.group.application.join;
+
+import com.grow.study_service.group.presentation.dto.JoinRequest;
+
+public interface GroupJoinService {
+    void joinGroup(Long memberId, Long groupId);
+    void sendJoinRequest(JoinRequest request, Long memberId);
+}

--- a/src/main/java/com/grow/study_service/group/application/join/GroupJoinServiceImpl.java
+++ b/src/main/java/com/grow/study_service/group/application/join/GroupJoinServiceImpl.java
@@ -1,0 +1,89 @@
+package com.grow.study_service.group.application.join;
+
+import com.grow.study_service.common.exception.ErrorCode;
+import com.grow.study_service.common.exception.service.ServiceException;
+import com.grow.study_service.group.presentation.dto.JoinRequest;
+import com.grow.study_service.groupmember.domain.enums.Role;
+import com.grow.study_service.groupmember.domain.model.GroupMember;
+import com.grow.study_service.groupmember.domain.repository.GroupMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroupJoinServiceImpl implements GroupJoinService {
+
+    private final GroupMemberRepository groupMemberRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * 지정된 멤버를 지정된 그룹에 가입시킵니다.
+     *
+     * 이 메서드는 먼저 해당 멤버가 이미 그룹에 가입되어 있는지 확인합니다. 이미 가입된 경우 {@link ServiceException}을 발생시킵니다.
+     * 이후 결제 서비스로 결제 요청을 전송해야 하며 (현재 TODO로 표시됨), 성공 시 그룹 멤버를 저장합니다.
+     *
+     * @param memberId 가입할 멤버의 ID
+     * @param groupId 가입할 그룹의 ID
+     * @throws ServiceException 그룹에 이미 가입된 경우 ({@link ErrorCode#GROUP_ALREADY_JOINED})
+     */
+    @Override
+    @Transactional
+    public void joinGroup(Long memberId, Long groupId) {
+        log.info("[GROUP][JOIN][START] memberId={} groupId={} - 그룹 가입 시작", memberId, groupId);
+
+        // 중복 가입 제거
+        if (groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId)) {
+            throw new ServiceException(ErrorCode.GROUP_ALREADY_JOINED);
+        }
+
+        // TODO 결제 서비스로 결제 요청 전송 필요
+
+        // 그룹에 멤버 추가
+        groupMemberRepository.save(GroupMember.create(memberId, groupId, Role.MEMBER));
+
+        log.info("[GROUP][JOIN][END] memberId={} groupId={} - 그룹 가입 완료", memberId, groupId);
+    }
+
+    /**
+     * 지정된 멤버가 그룹 가입 요청을 전송합니다.
+     *
+     * 이 메서드는 먼저 해당 멤버가 이미 그룹에 가입되어 있는지 확인합니다. 이미 가입된 경우 {@link ServiceException}을 발생시킵니다.
+     * 이후 Redis Set을 사용하여 중복 요청을 방지합니다. 이미 요청이 존재하면 예외를 발생시키고, 새로운 요청인 경우 Set에 추가한 후 7일 만료 시간을 설정합니다.
+     * 요청 처리 전후에 로그를 기록합니다.
+     *
+     * @param request 그룹 가입 요청 객체 (groupId 포함)
+     * @param memberId 요청을 보내는 멤버의 ID
+     * @throws ServiceException 그룹에 이미 가입된 경우 ({@link ErrorCode#GROUP_ALREADY_JOINED}) 또는 이미 가입 요청이 전송된 경우 ({@link ErrorCode#JOIN_REQUEST_ALREADY_SENT})
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public void sendJoinRequest(JoinRequest request, Long memberId) {
+        log.info("[GROUP][JOIN][START] memberId={} groupId={} - 그룹 가입 요청 전송 시작", memberId, request.getGroupId());
+
+        // 중복 가입 제거
+        if (groupMemberRepository.existsByGroupIdAndMemberId(request.getGroupId(), memberId)) {
+            throw new ServiceException(ErrorCode.GROUP_ALREADY_JOINED);
+        }
+
+        // 그룹장에게 요청 전송 (redis 사용, 중복 요청을 거르기 위해서 set 구조 사용)
+        String redisKey = "group:" + request.getGroupId() + ":join-joinRequests"; // 키 생성
+
+        // Sets에 추가하고 추가된 수 확인 (중복 요청 방지) - 값이 추가되면 1, 이미 존재하면 0 반환
+        Long added = redisTemplate.opsForSet().add(redisKey, String.valueOf(memberId));
+
+        if (added == 0L) {
+            throw new ServiceException(ErrorCode.JOIN_REQUEST_ALREADY_SENT);
+        }
+
+        long expireTime = 7L * 24 * 60 * 60; // 7일 후에 초기화
+        redisTemplate.expire(redisKey, expireTime, TimeUnit.SECONDS);
+
+        log.info("[GROUP][JOIN][END] memberId={} groupId={} - 그룹 가입 요청 전송 완료", memberId, request.getGroupId());
+    }
+}

--- a/src/main/java/com/grow/study_service/group/infra/persistence/repository/query/GroupQueryRepository.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/repository/query/GroupQueryRepository.java
@@ -1,0 +1,11 @@
+package com.grow.study_service.group.infra.persistence.repository.query;
+
+import com.grow.study_service.group.domain.enums.Category;
+import com.grow.study_service.group.presentation.dto.GroupSimpleResponse;
+
+import java.util.List;
+
+public interface GroupQueryRepository {
+
+    List<GroupSimpleResponse> findJoinedGroupsByMemberAndCategory(Long memberId, Category category);
+}

--- a/src/main/java/com/grow/study_service/group/infra/persistence/repository/query/GroupQueryRepositoryImpl.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/repository/query/GroupQueryRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.grow.study_service.group.infra.persistence.repository.query;
+
+import com.grow.study_service.group.domain.enums.Category;
+import com.grow.study_service.group.infra.persistence.entity.QGroupJpaEntity;
+import com.grow.study_service.group.presentation.dto.GroupSimpleResponse;
+import com.grow.study_service.groupmember.infra.persistence.entity.QGroupMemberJpaEntity;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class GroupQueryRepositoryImpl implements GroupQueryRepository {
+
+    private final JPAQueryFactory factory;
+
+    /**
+     * 주어진 회원 ID와 카테고리를 기반으로, 해당 회원이 가입한 그룹 목록을 조회합니다.
+     * 조회 결과는 지정된 카테고리에 속하는 그룹만 포함되며, 가입일(joinedAt) 기준으로 최신 순서로 정렬됩니다.
+     * QueryDSL을 사용하여 GroupMemberJpaEntity와 GroupJpaEntity를 ID 기반으로 조인하며,
+     * 결과를 GroupSimpleResponse DTO 리스트로 반환합니다.
+     *
+     * @param memberId 조회할 회원의 ID (필수, null 불가)
+     * @param category 그룹을 필터링할 카테고리 (예: 스포츠, 학습 등)
+     * @return GroupSimpleResponse 객체 리스트 (그룹 ID, 이름, 역할, 가입일 포함). 빈 리스트일 수 있음
+     */
+    public List<GroupSimpleResponse> findJoinedGroupsByMemberAndCategory(Long memberId, Category category) {
+        QGroupMemberJpaEntity groupMember = QGroupMemberJpaEntity.groupMemberJpaEntity;
+        QGroupJpaEntity group = QGroupJpaEntity.groupJpaEntity;
+
+        List<Tuple> tupleList = factory.select(group.id, group.name, groupMember.role, groupMember.joinedAt)
+                .from(groupMember)
+                .join(group)
+                .on(groupMember.groupId.eq(group.id)) // ID 기반 (GroupMember 테이블과 Group 테이블을 조인)
+                .where(
+                        groupMember.memberId.eq(memberId), // 멤버 ID가 같고
+                        group.category.eq(category) // 카테고리가 같음
+                )
+                .orderBy(groupMember.joinedAt.desc()) // 최신 가입 순서 정렬
+                .fetch();
+
+        return tupleList.stream()
+                .map(tuple -> new GroupSimpleResponse(
+                        tuple.get(group.id),
+                        tuple.get(group.name),
+                        tuple.get(groupMember.role),
+                        tuple.get(groupMember.joinedAt)
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/grow/study_service/group/presentation/controller/GroupFindController.java
+++ b/src/main/java/com/grow/study_service/group/presentation/controller/GroupFindController.java
@@ -2,9 +2,11 @@ package com.grow.study_service.group.presentation.controller;
 
 import com.grow.study_service.common.rsdata.RsData;
 import com.grow.study_service.group.application.GroupFacadeService;
+import com.grow.study_service.group.application.GroupTransactionService;
 import com.grow.study_service.group.domain.enums.Category;
 import com.grow.study_service.group.presentation.dto.GroupDetailResponse;
 import com.grow.study_service.group.presentation.dto.GroupResponse;
+import com.grow.study_service.group.presentation.dto.GroupSimpleResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,6 +18,7 @@ import java.util.List;
 public class GroupFindController {
 
     private final GroupFacadeService groupFacadeService;
+    private final GroupTransactionService groupService;
 
     // 전체 그룹 조회 (카테고리 별 조회 가능)
     @GetMapping()
@@ -40,6 +43,19 @@ public class GroupFindController {
                 "200",
                 "특정 그룹 조회 완료",
                 response
+        );
+    }
+
+    // 현재 가입 그룹을 조회하는 API (카테고리 별로 조회, 최신 가입 순으로 출력)
+    @GetMapping("/{category}/my-joined-groups")
+    public RsData<List<GroupSimpleResponse>> getMyJoinedGroups(@RequestHeader("X-Authorization-Id") Long memberId,
+                                                               @PathVariable("category") Category category){
+        List<GroupSimpleResponse> responses = groupService.getMyGroupsByCategory(category, memberId);
+
+        return new RsData<>(
+                "200",
+                "현재 가입 그룹 조회 완료",
+                responses
         );
     }
 }

--- a/src/main/java/com/grow/study_service/group/presentation/controller/GroupJoinController.java
+++ b/src/main/java/com/grow/study_service/group/presentation/controller/GroupJoinController.java
@@ -1,0 +1,41 @@
+package com.grow.study_service.group.presentation.controller;
+
+import com.grow.study_service.common.rsdata.RsData;
+import com.grow.study_service.group.application.join.GroupJoinService;
+import com.grow.study_service.group.presentation.dto.JoinRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/groups")
+public class GroupJoinController {
+
+    private final GroupJoinService groupJoinService;
+
+    // 그룹에 가입 요청 전송 API
+    @PostMapping("/join-request")
+    public RsData<Void> sendJoinRequestToGroup(@RequestHeader("X-Authorization-Id") Long memberId,
+                                  @RequestBody JoinRequest request) {
+
+        groupJoinService.sendJoinRequest(request, memberId);
+
+        return new RsData<>(
+                "201",
+                "그룹에 가입 요청 전송 완료"
+        );
+    }
+
+    // (멘토링) 그룹에 가입 전송 API (결제 후 자동 가입 진행)
+    @PostMapping("/join/{groupId}")
+    public RsData<Void> joinMentoring(@RequestHeader("X-Authorization-Id") Long memberId,
+                                  @PathVariable("groupId") Long groupId) {
+
+        groupJoinService.joinGroup(memberId, groupId); // TODO 결제 서비스로 요청을 전송해야 함
+
+        return new RsData<>(
+                "201",
+                "그룹에 가입 요청 전송 완료"
+        );
+    }
+}

--- a/src/main/java/com/grow/study_service/group/presentation/dto/GroupSimpleResponse.java
+++ b/src/main/java/com/grow/study_service/group/presentation/dto/GroupSimpleResponse.java
@@ -1,0 +1,17 @@
+package com.grow.study_service.group.presentation.dto;
+
+import com.grow.study_service.groupmember.domain.enums.Role;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class GroupSimpleResponse {
+
+    private Long groupId; // 그룹 아이디
+    private String groupName; // 그룹 이름
+    private Role role; // 그룹 내부에서의 역할 (리더, 멤버)
+    private LocalDateTime joinedAt; // 그룹 가입 시기
+}

--- a/src/main/java/com/grow/study_service/group/presentation/dto/JoinRequest.java
+++ b/src/main/java/com/grow/study_service/group/presentation/dto/JoinRequest.java
@@ -1,0 +1,12 @@
+package com.grow.study_service.group.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JoinRequest {
+
+    private final Long leaderId;
+    private final Long groupId;
+}

--- a/src/main/java/com/grow/study_service/groupmember/domain/model/GroupMember.java
+++ b/src/main/java/com/grow/study_service/groupmember/domain/model/GroupMember.java
@@ -47,6 +47,8 @@ public class GroupMember {
 	 */
 	private final LocalDateTime joinedAt;
 
+    private Long version;
+
     /**
      * 새로운 그룹 멤버를 생성하는 팩토리 메서드.
      * 그룹 멤버 ID는 null로 설정되며, 데이터베이스 삽입 시 자동 생성됩니다.
@@ -68,7 +70,8 @@ public class GroupMember {
                 memberId,
                 groupId,
                 role,
-                LocalDateTime.now() // 데이터베이스에 저장될 때는 현재 시각을 사용함. (자동 생성)
+                LocalDateTime.now(), // 데이터베이스에 저장될 때는 현재 시각을 사용함. (자동 생성)
+                null // 버전 자동 생성
         );
     }
 
@@ -88,8 +91,9 @@ public class GroupMember {
                                  Long memberId,
                                  Long groupId,
                                  Role role,
-                                 LocalDateTime joinedAt
-    ) {
+                                 LocalDateTime joinedAt,
+                                 Long version) {
+
         verifyParameters(memberId, groupId, role);
         verifyIdAndJoinedAt(groupMemberId, joinedAt);
 
@@ -98,7 +102,8 @@ public class GroupMember {
                 memberId,
                 groupId,
                 role,
-                joinedAt
+                joinedAt,
+                version
         );
     }
 

--- a/src/main/java/com/grow/study_service/groupmember/infra/persistence/entity/GroupMemberJpaEntity.java
+++ b/src/main/java/com/grow/study_service/groupmember/infra/persistence/entity/GroupMemberJpaEntity.java
@@ -4,13 +4,7 @@ import java.time.LocalDateTime;
 
 import com.grow.study_service.groupmember.domain.enums.Role;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,4 +30,7 @@ public class GroupMemberJpaEntity {
 	private Role role;
 
 	private LocalDateTime joinedAt;
+
+	@Version
+	private Long version;
 }

--- a/src/main/java/com/grow/study_service/groupmember/infra/persistence/mapper/GroupMemberMapper.java
+++ b/src/main/java/com/grow/study_service/groupmember/infra/persistence/mapper/GroupMemberMapper.java
@@ -30,7 +30,8 @@ public class GroupMemberMapper {
 				entity.getMemberId(),
 				entity.getGroupId(),
 				entity.getRole(),
-				entity.getJoinedAt()
+				entity.getJoinedAt(),
+				entity.getVersion()
 		);
 	}
 
@@ -49,7 +50,8 @@ public class GroupMemberMapper {
 				.memberId(domain.getMemberId())
 				.groupId(domain.getGroupId())
 				.role(domain.getRole())
-				.joinedAt(domain.getJoinedAt());
+				.joinedAt(domain.getJoinedAt())
+				.version(domain.getVersion());
 
 		if (domain.getGroupId() != null) {
 			builder.id(domain.getGroupMemberId());


### PR DESCRIPTION
## ✅ Check List(필수)
- [X] 코드에 주석 추가 완료
- [X] 테스트 통과 확인 (postman + h2 db)

+ 📸 Screenshot or Test Result
<img width="798" height="540" alt="스크린샷 2025-09-01 오후 8 43 45" src="https://github.com/user-attachments/assets/fef25f6c-1cda-4478-ba77-f41fa56b4c53" />

- 스터디 / 취미의 경우 가입 요청을 전송할 수 있도록 엔드포인트를 설계했습니다

<img width="745" height="565" alt="스크린샷 2025-09-01 오후 8 42 56" src="https://github.com/user-attachments/assets/7b47216a-10c7-48c4-b1d9-963fee6b934b" />

- 중복 요청의 경우 오류 처리

<img width="361" height="77" alt="스크린샷 2025-09-01 오후 8 42 42" src="https://github.com/user-attachments/assets/fcfecfa5-7cd1-4300-bfc0-df2327d8b5ba" />

- redis 에서 확인 가능한 값

--- 

<img width="793" height="814" alt="스크린샷 2025-09-01 오후 9 39 45" src="https://github.com/user-attachments/assets/8af01e8b-220a-4a43-9430-ef7c62f9680a" />

- 현재 내가 가입한 그룹을 확인할 수 있는 엔드포인트가 없어 급하게 추가했습니다 (프론트 만들다가 보니까 이게 없더라고요...)

## 📝 Note (주의 사항)

1. redis 는 list 대신 set 으로 사용했습니다 기본적으로 요청이 들어오는 순서대로 전달을 해야겠다고 생각했는데, 아무래도 중복 요청을 막는 것이 조금 더 효율적일 것 같았습니다 (찾아 보니 SNS 에서 친구 요청 보내는 것도 대부분 set 구조를 사용한다고 하더라구요!!!)
2. 7일 간 조회가 가능하도록 해 두고, 7일 후에는 자동 삭제되도록 했습니다 (굳이 쌓아 둘 필요가 있나 싶었습니다 근데 필요하다면 없앨 수 있습니다... 👍) 
3. 두 개의 코드 길이가 그리 길지 않아서 두 가지 기능 합쳐서 올렸습니다 미안합니다... 
4. 왜 jpql 보다 qureydsl 이 더 좋을까요 아무래도 자동 완성이 너무 편하기 때문일까요 그리고 컴파일 에러로 잡을 수 잇다는 점 때문일까요... 하여튼 쿼리 썼읍니다
5. 좀 주먹구구로 만든 거 같은데 첨언 환영하겟습니다 
6. 아 그리고 그룹 바로 가입되도록 한 건 테스트는 성공했는데, 결제 서비스랑 연동하고 알림 서비스랑 연동하려면 이후 테스트가 더 중요할 것 같아서 이후에 보강해서 같이 올리겠습니다 
