### PR TITLE
✨ feat: 그룹별 가입 요청 확인 API 엔드포인트 구현

### DIFF
--- a/src/main/java/com/grow/study_service/group/application/GroupFacadeService.java
+++ b/src/main/java/com/grow/study_service/group/application/GroupFacadeService.java
@@ -3,6 +3,7 @@ package com.grow.study_service.group.application;
 import com.grow.study_service.group.application.api.MemberApiService;
 import com.grow.study_service.group.application.dto.GroupDetailPrep;
 import com.grow.study_service.group.application.dto.GroupWithLeader;
+import com.grow.study_service.group.application.join.GroupJoinService;
 import com.grow.study_service.group.domain.enums.Category;
 import com.grow.study_service.group.presentation.dto.GroupDetailResponse;
 import com.grow.study_service.group.presentation.dto.GroupResponse;
@@ -12,6 +13,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.grow.study_service.group.application.api.MemberApiServiceImpl.*;
 
 /**
  * GroupMainService는 파사드 패턴을 적용하여
@@ -27,6 +30,7 @@ public class GroupFacadeService {
 
     private final GroupTransactionService groupTransactionService; // 트랜잭션 처리 담당
     private final MemberApiService memberApiService; // 외부 API 호출 담당
+    private final GroupJoinService groupJoinService;
 
     public List<GroupResponse> getAllGroupsByCategory(Category category) {
         // 트랜잭션 내에서 그룹 + 리더의 데이터를 가져온 후,
@@ -51,5 +55,13 @@ public class GroupFacadeService {
         String memberName = memberApiService.getMemberName(detailPrep.getLeaderId());
         // 그룹 상세 정보 생성 (DTO 생성)
         return groupTransactionService.buildGroupDetailResponse(detailPrep, memberName, groupId);
+    }
+
+    // 가입 요청 조회 + 멤버 정보 api 조회
+    public List<MemberInfo> getJoinMemberInfo(Long groupId) {
+        List<Long> allMemberIds = groupJoinService.prepareFindJoinRequest(groupId);
+
+        // 동기적으로 결과 받기 → 결과를 바로 이용해야 함
+        return memberApiService.getNicknameAndScore(allMemberIds).block();
     }
 }

--- a/src/main/java/com/grow/study_service/group/application/api/MemberApiService.java
+++ b/src/main/java/com/grow/study_service/group/application/api/MemberApiService.java
@@ -1,6 +1,11 @@
 package com.grow.study_service.group.application.api;
 
+import reactor.core.publisher.Mono;
+
 import java.util.List;
+import java.util.Map;
+
+import static com.grow.study_service.group.application.api.MemberApiServiceImpl.*;
 
 public interface MemberApiService {
     /**
@@ -12,4 +17,9 @@ public interface MemberApiService {
      * 외부 API 호출로 멤버 이름 조회 (리스트 처리)
      */
     List<String> fetchMemberNames(List<Long> memberIds);
+
+    /**
+     * 가입 요청 정보 확인
+     */
+    Mono<List<MemberInfo>> getNicknameAndScore(List<Long> memberIds);
 }

--- a/src/main/java/com/grow/study_service/group/application/api/MemberApiServiceImpl.java
+++ b/src/main/java/com/grow/study_service/group/application/api/MemberApiServiceImpl.java
@@ -12,8 +12,6 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Slf4j

--- a/src/main/java/com/grow/study_service/group/application/api/MemberApiServiceImpl.java
+++ b/src/main/java/com/grow/study_service/group/application/api/MemberApiServiceImpl.java
@@ -1,13 +1,19 @@
 package com.grow.study_service.group.application.api;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -17,6 +23,9 @@ public class MemberApiServiceImpl implements MemberApiService {
 
     @Value("${member.name.path}")
     private String memberNamePath;
+
+    @Value("${member.info.path}")
+    private String memberInfoPath;
 
     private final WebClient webClient;
 
@@ -81,5 +90,44 @@ public class MemberApiServiceImpl implements MemberApiService {
         return memberIds.stream()
                 .map(this::getMemberName)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 주어진 memberId 리스트를 기반으로 외부 서버에서 닉네임과 점수를 비동기 병렬 요청으로 조회합니다.
+     * WebClient를 활용해 여러 요청을 동시에 처리하여 성능을 최적화합니다.
+     * 에러 발생 시 로그를 남기고 빈 MemberInfo를 반환하며, 전체 결과를 Mono<List<MemberInfo>>로 제공합니다.
+     *
+     * @param memberIds 조회할 회원 ID 리스트 (필수, 빈 리스트 시 빈 결과 반환)
+     * @return Mono<List<MemberInfo>> - 닉네임과 점수 리스트 (비동기 처리 결과)
+     */
+    @Override
+    public Mono<List<MemberInfo>> getNicknameAndScore(List<Long> memberIds) {
+        if (memberIds.isEmpty()) {
+            return Mono.just(List.of()); // 입력 리스트가 비어 있으면, 불필요한 작업을 피하고 바로 빈 리스트를 Mono로 감싸 반환
+        }
+
+        // 전체 흐름: ID 리스트를 Flux로 변환 → 병렬로 API 호출 → 결과 모아서 리스트 반환
+        return Flux.fromIterable(memberIds) // 리스트(memberIds)를 Flux(스트림)로 변환 Flux: "여러" 아이템을 순차적으로 처리
+                .parallel() // Flux를 병렬 모드로 전환 → 여러 스레드에서 동시에 작업을 나눠 처리
+                .runOn(Schedulers.parallel()) // 병렬 처리를 위한 스케줄러를 지정 Schedulers.parallel(): CPU 코어 수에 맞는 스레드 풀을 사용해 병렬 작업을 실행
+                .flatMap(memberId -> webClient.get() // 입력을 받아 새로운 Mono/Flux를 반환하고, 이를 평평하게(flatten) 합침
+                        .uri(memberInfoPath, memberId)
+                        .retrieve() // API 응답을 처리하기 시작
+                        .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                                response -> Mono.error(new RuntimeException("API 호출 실패: " + response.statusCode())))
+                        .bodyToMono(MemberInfo.class) // 응답 본문을 MemberInfo 객체로 변환
+                        .onErrorResume(e -> { // 에러가 발생해도 스트림이 중단되지 않도록 처리
+                            log.error("[Member Info API error] API 호출 실패: {}", e.getMessage());
+                            return Mono.empty(); // 에러 발생 시 빈 MemberInfo 반환
+                        }))
+                .sequential() // 병렬 처리 결과를 순차 Flux 로 합침 (병렬 처리 후 결과를 순서대로 모으는 데 필요)
+                .collectList(); // 결과를 리스트로 반환
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MemberInfo {
+        private String nickname;
+        private double score;
     }
 }

--- a/src/main/java/com/grow/study_service/group/application/join/GroupJoinService.java
+++ b/src/main/java/com/grow/study_service/group/application/join/GroupJoinService.java
@@ -1,8 +1,13 @@
 package com.grow.study_service.group.application.join;
 
-import com.grow.study_service.group.presentation.dto.JoinRequest;
+import com.grow.study_service.group.presentation.dto.join.JoinInfoResponse;
+import com.grow.study_service.group.presentation.dto.join.JoinRequest;
+
+import java.util.List;
 
 public interface GroupJoinService {
     void joinGroup(Long memberId, Long groupId);
     void sendJoinRequest(JoinRequest request, Long memberId);
+    List<JoinInfoResponse> findGroupIdsByLeaderId(Long memberId);
+    List<Long> prepareFindJoinRequest(Long groupId);
 }

--- a/src/main/java/com/grow/study_service/group/domain/repository/GroupRepository.java
+++ b/src/main/java/com/grow/study_service/group/domain/repository/GroupRepository.java
@@ -11,4 +11,5 @@ public interface GroupRepository {
 	Optional<Group> findById(Long groupId);
 	void delete(Group group);
     List<Group> findAllByCategory(Category category);
+	String findGroupNameById(Long groupId);
 }

--- a/src/main/java/com/grow/study_service/group/infra/persistence/repository/GroupJpaRepository.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/repository/GroupJpaRepository.java
@@ -4,10 +4,15 @@ import com.grow.study_service.group.domain.enums.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.grow.study_service.group.infra.persistence.entity.GroupJpaEntity;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface GroupJpaRepository
 	extends JpaRepository<GroupJpaEntity, Long> {
     List<GroupJpaEntity> findAllByCategory(Category category);
+
+    @Query("select g.name from GroupJpaEntity g where g.id = :groupId")
+    String findGroupNameById(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/grow/study_service/group/infra/persistence/repository/GroupRepositoryImpl.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/repository/GroupRepositoryImpl.java
@@ -41,4 +41,16 @@ public class GroupRepositoryImpl implements GroupRepository {
 				.map(GroupMapper::toDomain)
 				.toList();
 	}
+
+	/**
+	 * 주어진 그룹 ID로 그룹 이름을 조회합니다.
+	 * 그룹이 존재하지 않으면 null을 반환합니다.
+	 *
+	 * @param groupId 조회할 그룹 ID
+	 * @return 그룹 이름 (String), 없으면 null
+	 */
+	@Override
+	public String findGroupNameById(Long groupId) {
+		return groupJpaRepository.findGroupNameById(groupId);
+	}
 }

--- a/src/main/java/com/grow/study_service/group/infra/persistence/repository/query/GroupQueryRepository.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/repository/query/GroupQueryRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface GroupQueryRepository {
 
     List<GroupSimpleResponse> findJoinedGroupsByMemberAndCategory(Long memberId, Category category);
+
+    List<Long> findGroupIdsByLeaderId(Long memberId);
 }

--- a/src/main/java/com/grow/study_service/group/presentation/controller/GroupJoinController.java
+++ b/src/main/java/com/grow/study_service/group/presentation/controller/GroupJoinController.java
@@ -1,22 +1,30 @@
 package com.grow.study_service.group.presentation.controller;
 
 import com.grow.study_service.common.rsdata.RsData;
+import com.grow.study_service.group.application.GroupFacadeService;
+import com.grow.study_service.group.application.api.MemberApiServiceImpl.MemberInfo;
 import com.grow.study_service.group.application.join.GroupJoinService;
-import com.grow.study_service.group.presentation.dto.JoinRequest;
+import com.grow.study_service.group.presentation.dto.join.JoinInfoResponse;
+import com.grow.study_service.group.presentation.dto.join.JoinRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/groups")
 public class GroupJoinController {
 
     private final GroupJoinService groupJoinService;
+    private final GroupFacadeService groupFacadeService;
 
     // 그룹에 가입 요청 전송 API
-    @PostMapping("/join-request")
+    @PostMapping("/send/join-request")
     public RsData<Void> sendJoinRequestToGroup(@RequestHeader("X-Authorization-Id") Long memberId,
-                                  @RequestBody JoinRequest request) {
+                                               @RequestBody JoinRequest request) {
 
         groupJoinService.sendJoinRequest(request, memberId);
 
@@ -29,7 +37,7 @@ public class GroupJoinController {
     // (멘토링) 그룹에 가입 전송 API (결제 후 자동 가입 진행)
     @PostMapping("/join/{groupId}")
     public RsData<Void> joinMentoring(@RequestHeader("X-Authorization-Id") Long memberId,
-                                  @PathVariable("groupId") Long groupId) {
+                                      @PathVariable("groupId") Long groupId) {
 
         groupJoinService.joinGroup(memberId, groupId); // TODO 결제 서비스로 요청을 전송해야 함
 
@@ -38,4 +46,33 @@ public class GroupJoinController {
                 "그룹에 가입 요청 전송 완료"
         );
     }
+
+    // 그룹 확인 API (그룹장 전용)
+    @GetMapping("/check/join-request")
+    public RsData<List<JoinInfoResponse>> checkJoinRequestByGroupId(@RequestHeader("X-Authorization-Id") Long memberId) {
+
+        List<JoinInfoResponse> infos = groupJoinService.findGroupIdsByLeaderId(memberId);
+
+        log.info("[GROUP][JOIN][END] memberId={} - 그룹 리스트 조회 완료", memberId);
+        return new RsData<>(
+                "200",
+                "그룹별 가입 요청을 위한 그룹 ID 목록 반환 완료",
+                infos);
+    }
+
+    // 그룹별 가입 요청 확인 API (ID 기반, 그룹장 전용)
+    @GetMapping("/check/join-request/{groupId}")
+    public RsData<List<MemberInfo>> checkJoinRequest(
+            @PathVariable("groupId") Long groupId) {
+
+        List<MemberInfo> responses = groupFacadeService.getJoinMemberInfo(groupId);
+
+        return new RsData<>("200",
+                "가입 요청 확인 완료",
+                responses);
+    }
+
+    // 가입 요청 수락 API
+
+    // 가입 요청 거절 API
 }

--- a/src/main/java/com/grow/study_service/group/presentation/dto/join/JoinInfoResponse.java
+++ b/src/main/java/com/grow/study_service/group/presentation/dto/join/JoinInfoResponse.java
@@ -1,0 +1,12 @@
+package com.grow.study_service.group.presentation.dto.join;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JoinInfoResponse {
+
+    private final Long groupId;
+    private final String groupName;
+}

--- a/src/main/java/com/grow/study_service/group/presentation/dto/join/JoinMemberInfoResponse.java
+++ b/src/main/java/com/grow/study_service/group/presentation/dto/join/JoinMemberInfoResponse.java
@@ -1,0 +1,12 @@
+package com.grow.study_service.group.presentation.dto.join;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JoinMemberInfoResponse {
+
+    private int score; // 신뢰도 점수
+    private String nickname; // 닉네임
+}

--- a/src/main/java/com/grow/study_service/group/presentation/dto/join/JoinRequest.java
+++ b/src/main/java/com/grow/study_service/group/presentation/dto/join/JoinRequest.java
@@ -1,4 +1,4 @@
-package com.grow.study_service.group.presentation.dto;
+package com.grow.study_service.group.presentation.dto.join;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/test/java/com/grow/study_service/comment/application/DeleteCommentTest.java
+++ b/src/test/java/com/grow/study_service/comment/application/DeleteCommentTest.java
@@ -65,7 +65,7 @@ public class DeleteCommentTest {
     @BeforeEach
     void outerSetUp() {
         /* ① 그룹 도메인 객체 생성 및 저장 */
-        group = groupRepository.save(Group.create("스터디 그룹", Category.STUDY, "도메인 테스트용 그룹"));
+        group = groupRepository.save(Group.create("스터디 그룹", Category.STUDY, "도메인 테스트용 그룹", null, null, 0));
 
         /* ② 게시판 도메인 객체 생성 및 저장 */
         board = Board.create(


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (postman + log)

+ 📸 Screenshot or Test Result

<img width="812" height="635" alt="스크린샷 2025-09-02 오후 5 56 45" src="https://github.com/user-attachments/assets/cc3be28f-4458-4e8d-b27b-d75624977183" />

- 본인의 Id 를 기반으로 가입 요청을 확인할 수 있는 그룹을 조회하는 API 입니다

<img width="821" height="553" alt="스크린샷 2025-09-02 오후 5 56 53" src="https://github.com/user-attachments/assets/1cd9893d-3f95-4491-aec4-b9f9042800e0" />

- 확인 가능한 그룹이 없을 경우 빈 리스트로 반환됩니다
- 클라이언트의 헤더 코드에 추가하고, 빈 리스트의 경우 가입 요청 확인하기 같은 아이콘이 보이지 않게 할까 고민도 하는 중입니다... 고민되네요...

<img width="824" height="631" alt="스크린샷 2025-09-02 오후 6 08 49" src="https://github.com/user-attachments/assets/8e944a5c-3e7c-408b-be5e-73545bd95585" />

- 가입 요청을 보낸 사람의 세부 정보를 확인하는 API 입니다 (현재는 닉네임과 신뢰도 점수만 넘길 수 있도록 구현했습니다)

<img width="808" height="202" alt="스크린샷 2025-09-02 오후 6 08 58" src="https://github.com/user-attachments/assets/0964d868-ce10-453f-8d27-17725c5208eb" />

- 멤버 서비스에서의 로그 확인

## 📝 Note (주의 사항)
1. TODO 로 추가해야 할 부분을 적어두었습니다 (필요 없을 거 같기도 하고...)
2. 두 개의 API 를 하나로 만들 수 없을까? -> 생각해 봤는데 외부 API 를 호출하는 부분을 분리하고 있어서, 
이를 어떻게 그룹 이름 + 멤버 정보 합쳐서 보낼 수 있을까 고민을 했는데 너무 복잡해지길래... 두 개로 분리해서 그룹 이름을 얻어오는 것 따로 / 멤버 정보 리스트 따로 반환하는 것으로 했습니다 
3. API 요청을 보낼 때 Flux 타입을 이용했습니다 한 번에 한 개의 요청만 보내는 것이 아니고, 보내야 하는 요청을 병렬적으로 전부 전송한 다음에 응답이 다 도착할 때까지 기다립니다 (단건 전송 -> 수신 완료, 이후에 다시 단건 전송 -> ... 의 경우보다는 대용량이 필요할 때 성능적으로 우수할 것 같아요 (약간 오버 엔지니어링 같기도 합니다) + 저도 잘 모르는 부분이라 상세하게 주석 추가해 두었습니다 
4. 이제 프론트 만지고 카프카 공부해서 알림 전송하러 갔다오겠습니다...
