### PR TITLE
✨ feat: 가입 요청을 수락하고 거절할 수 있는 API 엔드포인트 설정

### DIFF
--- a/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
+++ b/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     GROUP_NOT_FOUND("404", "그룹을 찾을 수 없습니다." ),
     GROUP_ALREADY_JOINED("409", "이미 가입된 그룹입니다."),
     JOIN_REQUEST_ALREADY_SENT("409", "이미 가입 요청을 보냈습니다." ),
+    NO_PERMISSION_TO_ACCEPT_REQUEST("403", "요청을 수락할 권한이 없습니다."),
 
     /**
      * 📌 2. 그룹 멤버(Group Member) 관련
@@ -30,6 +31,7 @@ public enum ErrorCode {
     GROUP_MEMBER_NOT_FOUND("404", "그룹 멤버를 찾을 수 없습니다."),
     MEMBER_NOT_IN_GROUP("403", "그룹 멤버가 아닙니다. 접근 권한이 없습니다."),
     GROUP_OR_LEADER_NOT_FOUND("404", "그룹 또는 그룹의 리더를 찾을 수 없습니다. " ),
+    ALREADY_ACCEPTED_REQUEST("409", "이미 가입 요청을 수락했습니다."),
 
 
     /**
@@ -75,8 +77,7 @@ public enum ErrorCode {
     INVALID_POST_ACCESS("403", "이 게시글에 접근할 권한이 없습니다. postId나 그룹 가입 상태를 확인해 주세요. "),
     COMMENT_ALREADY_EXISTS("409", "이미 동일한 댓글이 존재합니다." ),
     COMMENT_NOT_FOUND("404", "댓글을 찾을 수 없습니다."),
-    INVALID_COMMENT_ACCESS("403", "이 댓글에 접근할 권한이 없습니다." ),
-    ;
+    INVALID_COMMENT_ACCESS("403", "이 댓글에 접근할 권한이 없습니다." ),;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/grow/study_service/group/application/join/GroupJoinService.java
+++ b/src/main/java/com/grow/study_service/group/application/join/GroupJoinService.java
@@ -1,5 +1,6 @@
 package com.grow.study_service.group.application.join;
 
+import com.grow.study_service.group.presentation.dto.join.JoinConfirmRequest;
 import com.grow.study_service.group.presentation.dto.join.JoinInfoResponse;
 import com.grow.study_service.group.presentation.dto.join.JoinRequest;
 
@@ -10,4 +11,6 @@ public interface GroupJoinService {
     void sendJoinRequest(JoinRequest request, Long memberId);
     List<JoinInfoResponse> findGroupIdsByLeaderId(Long memberId);
     List<Long> prepareFindJoinRequest(Long groupId);
+    void acceptJoinRequest(Long memberId, JoinConfirmRequest request);
+    void rejectJoinRequest(Long memberId, JoinConfirmRequest request);
 }

--- a/src/main/java/com/grow/study_service/group/presentation/controller/GroupJoinController.java
+++ b/src/main/java/com/grow/study_service/group/presentation/controller/GroupJoinController.java
@@ -4,6 +4,7 @@ import com.grow.study_service.common.rsdata.RsData;
 import com.grow.study_service.group.application.GroupFacadeService;
 import com.grow.study_service.group.application.api.MemberApiServiceImpl.MemberInfo;
 import com.grow.study_service.group.application.join.GroupJoinService;
+import com.grow.study_service.group.presentation.dto.join.JoinConfirmRequest;
 import com.grow.study_service.group.presentation.dto.join.JoinInfoResponse;
 import com.grow.study_service.group.presentation.dto.join.JoinRequest;
 import lombok.RequiredArgsConstructor;
@@ -62,8 +63,7 @@ public class GroupJoinController {
 
     // 그룹별 가입 요청 확인 API (ID 기반, 그룹장 전용)
     @GetMapping("/check/join-request/{groupId}")
-    public RsData<List<MemberInfo>> checkJoinRequest(
-            @PathVariable("groupId") Long groupId) {
+    public RsData<List<MemberInfo>> checkJoinRequest(@PathVariable("groupId") Long groupId) {
 
         List<MemberInfo> responses = groupFacadeService.getJoinMemberInfo(groupId);
 
@@ -73,6 +73,28 @@ public class GroupJoinController {
     }
 
     // 가입 요청 수락 API
+    @PostMapping("/accept-request")
+    public RsData<Void> acceptJoinRequest(@RequestHeader("X-Authorization-Id") Long memberId,
+                                          @RequestBody JoinConfirmRequest request) {
+
+        groupJoinService.acceptJoinRequest(memberId, request);
+
+        return new RsData<>(
+                "200",
+                "가입 요청 수락 완료"
+        );
+    }
 
     // 가입 요청 거절 API
+    @PostMapping("/reject-request")
+    public RsData<Void> rejectJoinRequest(@RequestHeader("X-Authorization-Id") Long memberId,
+                                          @RequestBody JoinConfirmRequest request) {
+
+        groupJoinService.rejectJoinRequest(memberId, request);
+
+        return new RsData<>(
+                "200",
+                "가입 요청 거절 완료"
+        );
+    }
 }

--- a/src/main/java/com/grow/study_service/group/presentation/dto/join/JoinConfirmRequest.java
+++ b/src/main/java/com/grow/study_service/group/presentation/dto/join/JoinConfirmRequest.java
@@ -1,0 +1,22 @@
+package com.grow.study_service.group.presentation.dto.join;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JoinConfirmRequest {
+
+    /**
+     * 가입 요청을 전송한 그룹의 ID
+     */
+    @NotNull
+    private final Long groupId;
+
+    /**
+     * 가입 요청을 전송했던 회원의 ID
+     */
+    @NotNull
+    private final Long memberId;
+}

--- a/src/main/java/com/grow/study_service/groupmember/domain/repository/GroupMemberRepository.java
+++ b/src/main/java/com/grow/study_service/groupmember/domain/repository/GroupMemberRepository.java
@@ -3,6 +3,7 @@ package com.grow.study_service.groupmember.domain.repository;
 import java.util.Optional;
 
 import com.grow.study_service.groupmember.domain.model.GroupMember;
+import jakarta.validation.constraints.NotNull;
 
 public interface GroupMemberRepository {
 	GroupMember save(GroupMember member);
@@ -13,4 +14,6 @@ public interface GroupMemberRepository {
 	boolean existsByMemberIdAndPostGroup(Long postId, Long memberId);
     int findMemberCountByGroupId(Long groupId);
 	Optional<GroupMember> findByGroupIdAndLeader(Long groupId);
+	boolean isLeader(Long groupId, Long memberId);
+	boolean existsByMemberIdAndGroupId(Long memberId, Long groupId);
 }

--- a/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberJpaRepository.java
+++ b/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberJpaRepository.java
@@ -11,30 +11,41 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface GroupMemberJpaRepository
-	extends JpaRepository<GroupMemberJpaEntity, Long> {
-	Optional<GroupMemberJpaEntity> findByMemberIdAndGroupId(Long memberId, Long groupId);
-	boolean existsByGroupIdAndMemberId(Long groupId, Long memberId);
+        extends JpaRepository<GroupMemberJpaEntity, Long> {
+    Optional<GroupMemberJpaEntity> findByMemberIdAndGroupId(Long memberId, Long groupId);
 
-	/**
-	 * 주어진 postId에 해당하는 포스트가 속한 그룹에 memberId의 멤버가 속해 있는지 확인합니다.
-	 *
-	 * 이 메서드는 GroupMemberJpaEntity, BoardJpaEntity, PostJpaEntity를 조인하여
-	 * 해당 포스트의 그룹 ID를 통해 멤버의 존재 여부를 검사합니다.
-	 * 존재할 경우 true, 그렇지 않을 경우 false를 반환합니다.
-	 *
-	 * @param postId 확인할 포스트의 ID
-	 * @param memberId 확인할 멤버의 ID
-	 * @return 멤버가 해당 포스트의 그룹에 속해 있는지 여부 (true/false)
-	 */
-	@Query("select case when (count(gm) > 0) then true else false end " + // count(gm) > 0 = boolean 타입으로 바꾸기 위해
-			"from GroupMemberJpaEntity gm " +
-			"join BoardJpaEntity b on gm.groupId = b.groupId " +
-			"join PostJpaEntity p on p.boardId = b.id " +
-			"where p.id = :postId and gm.memberId = :memberId") // 주어진 postId와 memberId로 필터링
-	boolean existsByMemberIdAndPostGroup(@Param("postId") Long postId,
-										 @Param("memberId") Long memberId);
+    boolean existsByGroupIdAndMemberId(Long groupId, Long memberId);
+
+    /**
+     * 주어진 postId에 해당하는 포스트가 속한 그룹에 memberId의 멤버가 속해 있는지 확인합니다.
+     * <p>
+     * 이 메서드는 GroupMemberJpaEntity, BoardJpaEntity, PostJpaEntity를 조인하여
+     * 해당 포스트의 그룹 ID를 통해 멤버의 존재 여부를 검사합니다.
+     * 존재할 경우 true, 그렇지 않을 경우 false를 반환합니다.
+     *
+     * @param postId   확인할 포스트의 ID
+     * @param memberId 확인할 멤버의 ID
+     * @return 멤버가 해당 포스트의 그룹에 속해 있는지 여부 (true/false)
+     */
+    @Query("select case when (count(gm) > 0) then true else false end " + // count(gm) > 0 = boolean 타입으로 바꾸기 위해
+            "from GroupMemberJpaEntity gm " +
+            "join BoardJpaEntity b on gm.groupId = b.groupId " +
+            "join PostJpaEntity p on p.boardId = b.id " +
+            "where p.id = :postId and gm.memberId = :memberId")
+    // 주어진 postId와 memberId로 필터링
+    boolean existsByMemberIdAndPostGroup(@Param("postId") Long postId,
+                                         @Param("memberId") Long memberId);
 
     long countByGroupId(Long groupId);
 
     List<GroupMemberJpaEntity> findByGroupIdAndRole(Long groupId, Role role);
+
+    @Query("select case when count(gm) > 0 then true else false end " +
+            "from GroupMemberJpaEntity gm " +
+            "where gm.groupId = :groupId and gm.role = :role and gm.memberId = :memberId")
+    boolean isLeader(@Param("groupId") Long groupId,
+                     @Param("role") Role role,
+                     @Param("memberId") Long memberId);
+
+    boolean existsByMemberIdAndGroupId(Long memberId, Long groupId);
 }

--- a/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberRepositoryImpl.java
+++ b/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberRepositoryImpl.java
@@ -86,4 +86,14 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepository {
 				.map(GroupMemberMapper::toDomain)
 				.findFirst();
 	}
+
+	@Override
+	public boolean isLeader(Long groupId, Long memberId) {
+		return groupMemberJpaRepository.isLeader(groupId, Role.LEADER, memberId);
+	}
+
+	@Override
+	public boolean existsByMemberIdAndGroupId(Long memberId, Long groupId) {
+		return groupMemberJpaRepository.existsByMemberIdAndGroupId(memberId, groupId);
+	}
 }


### PR DESCRIPTION
## ✅ Check List(필수)
- [X] 코드에 주석 추가 완료
- [X] 테스트 통과 확인 (postman)

+ 📸 Screenshot or Test Result

### memberId = 10 을 가진 회원이 groupId = 1 에 요청을 보냈다고 가정 

<img width="795" height="388" alt="스크린샷 2025-09-02 오후 9 19 47" src="https://github.com/user-attachments/assets/f4ab6dcf-8840-4ad5-b856-40bbc85df9ad" />
<img width="615" height="116" alt="스크린샷 2025-09-02 오후 8 56 59" src="https://github.com/user-attachments/assets/ea531ea0-45ba-4d8a-affe-732038e11e86" />

- 가입 요청 수락 이후 새로운 필드 등록

<img width="803" height="580" alt="스크린샷 2025-09-02 오후 8 57 22" src="https://github.com/user-attachments/assets/a3837ac9-0318-47eb-ac2c-ec785c08da77" />

- 요청 수락 권한이 없는 경우 (그룹장만 수락, 거절이 가능합니다)

<img width="813" height="588" alt="스크린샷 2025-09-02 오후 9 07 50" src="https://github.com/user-attachments/assets/e078819a-4127-48f1-b350-d070207aefbd" />

- 이미 가입 요청을 수락했는데, 또 한 번 더 누른 경우 -> 오류 발생합니다

<img width="827" height="558" alt="스크린샷 2025-09-02 오후 9 09 35" src="https://github.com/user-attachments/assets/13635e6a-6ed3-4fb6-aef2-2bdeb6109058" />
<img width="571" height="95" alt="스크린샷 2025-09-02 오후 9 09 54" src="https://github.com/user-attachments/assets/811097e5-72f2-4b99-a3b8-050a1a210a69" />

- 가입 요청 거절 경우, 새로운 필드가 등록되지 않습니다

## 📝 Note (주의 사항)
1. 아직 알림 부분은 구현되지 않았습니다 -> 이건 카프카로 연동할 수 있는 방법 제가 열심ㅅ히 공부해 오겠습니다... 
(알림까지는 사실 오버 엔지니어링인가? 싶긴 한데 학습 목적으로 했다고 하면 뭐... 봐주겟죠~!)
