### PR TITLE
✨ feat: 알림 이벤트 발행 로직 구현 #45

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// kafka
+	implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
+++ b/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     GROUP_ALREADY_JOINED("409", "이미 가입된 그룹입니다."),
     JOIN_REQUEST_ALREADY_SENT("409", "이미 가입 요청을 보냈습니다." ),
     NO_PERMISSION_TO_ACCEPT_REQUEST("403", "요청을 수락할 권한이 없습니다."),
+    JOIN_REQUEST_NOT_FOUND("404", "해당 그룹에 참여 요청이 전송되지 않았습니다." ),
 
     /**
      * 📌 2. 그룹 멤버(Group Member) 관련
@@ -32,7 +33,8 @@ public enum ErrorCode {
     MEMBER_NOT_IN_GROUP("403", "그룹 멤버가 아닙니다. 접근 권한이 없습니다."),
     GROUP_OR_LEADER_NOT_FOUND("404", "그룹 또는 그룹의 리더를 찾을 수 없습니다. " ),
     ALREADY_ACCEPTED_REQUEST("409", "이미 가입 요청을 수락했습니다."),
-
+    JOIN_REQUEST_MEMBER_NOT_FOUND("404", "해당 그룹에 참여 요청을 전송하지 않았거나 이미 처리된 가입 요청입니다."),
+    JOIN_REQUEST_ALREADY_REMOVED("409", "이미 처리된 가입 요청입니다." ),
 
     /**
      * 📌 3. 게시판(Board) 관련
@@ -77,7 +79,8 @@ public enum ErrorCode {
     INVALID_POST_ACCESS("403", "이 게시글에 접근할 권한이 없습니다. postId나 그룹 가입 상태를 확인해 주세요. "),
     COMMENT_ALREADY_EXISTS("409", "이미 동일한 댓글이 존재합니다." ),
     COMMENT_NOT_FOUND("404", "댓글을 찾을 수 없습니다."),
-    INVALID_COMMENT_ACCESS("403", "이 댓글에 접근할 권한이 없습니다." ),;
+    INVALID_COMMENT_ACCESS("403", "이 댓글에 접근할 권한이 없습니다." ),
+    ;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/grow/study_service/common/init/DataInit.java
+++ b/src/main/java/com/grow/study_service/common/init/DataInit.java
@@ -16,6 +16,8 @@ import com.grow.study_service.post.domain.repository.PostRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -30,9 +32,14 @@ public class DataInit implements CommandLineRunner {
     private final GroupMemberRepository groupMemberRepository;
     private final PostRepository postRepository;
     private final BoardRepository boardRepository;
+    private final RedisConnectionFactory redisConnectionFactory;
 
     @Override
     public void run(String... args) throws Exception {
+        // redis 초기화 로직 실행
+        redisConnectionFactory.getConnection().serverCommands().flushAll();
+        log.debug("redis flush all.");
+
         List<Group> groups = new ArrayList<>();
 
         // ------- 그룹 생성 ------- //

--- a/src/main/java/com/grow/study_service/common/util/JsonUtils.java
+++ b/src/main/java/com/grow/study_service/common/util/JsonUtils.java
@@ -1,0 +1,30 @@
+package com.grow.study_service.common.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JsonUtils {
+
+    private JsonUtils() {}
+
+    /**
+     * 주어진 객체를 JSON 문자열로 변환합니다.
+     *
+     * 이 메서드는 Jackson의 ObjectMapper를 사용하여 객체를 직렬화합니다.
+     * 변환 중 오류가 발생하면 RuntimeException을 던집니다.
+     *
+     * @param object JSON으로 변환할 객체. null이 허용되며, null은 "null" 문자열로 변환됩니다.
+     * @return 객체를 나타내는 JSON 문자열.
+     * @throws RuntimeException JSON 직렬화에 실패할 경우 발생합니다. 내부적으로 JsonProcessingException을 래핑합니다.
+     */
+    public static String toJsonString(Object object) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("JSON 직렬화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/grow/study_service/group/application/event/GroupJoinRequestSentEvent.java
+++ b/src/main/java/com/grow/study_service/group/application/event/GroupJoinRequestSentEvent.java
@@ -1,0 +1,14 @@
+package com.grow.study_service.group.application.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 그룹에 가입 요청이 전송된 후 발생되는 이벤트
+@Getter
+@AllArgsConstructor
+public class GroupJoinRequestSentEvent {
+
+    private final Long memberId; // 알림을 받는 사람의 아이디
+    private final String message; // 알림 내용
+    private final NotificationType notificationType; // 알림 타입 (그룹 참여 요청, 그룹 참여 승인, 그룹 참여 거절)
+}

--- a/src/main/java/com/grow/study_service/group/application/event/NotificationType.java
+++ b/src/main/java/com/grow/study_service/group/application/event/NotificationType.java
@@ -1,0 +1,15 @@
+package com.grow.study_service.group.application.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationType {
+
+    GROUP_JOIN_REQUEST("[그룹 참여 요청]"),
+    GROUP_JOIN_APPROVAL("[그룹 참여 승인]"),
+    GROUP_JOIN_REJECTION("[그룹 참여 거절]");
+
+    private final String description;
+}

--- a/src/main/java/com/grow/study_service/group/domain/model/Group.java
+++ b/src/main/java/com/grow/study_service/group/domain/model/Group.java
@@ -95,8 +95,8 @@ public class Group {
                 null, // 자동 생성
                 category,
                 LocalDateTime.now(), // 데이터베이스에 저장될 때는 현재 시각을 사용함.
-                description,
                 name,
+                description,
                 amount,
                 0,
                 personalityTag, // null 가능


### PR DESCRIPTION
## ✅ Check List(필수)
- [X] 코드에 주석 추가 완료
- [X] 테스트 통과 확인 (postman + log + aws 확인)

---

+ 📸 Screenshot or Test Result

<img width="816" height="540" alt="스크린샷 2025-09-05 오후 6 10 56" src="https://github.com/user-attachments/assets/7807757f-0a52-49fe-8bea-2bbbb06c094b" />
<img width="1286" height="92" alt="스크린샷 2025-09-05 오후 6 10 50" src="https://github.com/user-attachments/assets/085bf27c-4409-40df-99d0-08f0f87ae642" />

- 가입 요청 전송 시 그룹 리더 id 를 기준으로 카프카에 메시지 발행됩니다

<img width="1276" height="108" alt="스크린샷 2025-09-05 오후 7 40 46" src="https://github.com/user-attachments/assets/9464895d-3bc6-497e-935a-a6c7cb4104ff" />

- 신청 / 거절 시에는 신청을 한 대상을 기준으로 카프카에 메시지를 발행합니다

<img width="834" height="526" alt="스크린샷 2025-09-05 오후 7 55 59" src="https://github.com/user-attachments/assets/4a94a2d7-c97f-4259-8675-8e694239f10c" />

- 예외 처리를 강화했습니다 
- 참여 요청을 전송하지 않았는데 승인 / 거절하는 경우 오류 발생합니다 

<img width="840" height="564" alt="스크린샷 2025-09-05 오후 7 56 19" src="https://github.com/user-attachments/assets/10d0c293-818e-46ea-897a-f6f28143cb65" />

- 이미 가입을 수락했을 경우 오류 발생합니다

<img width="836" height="514" alt="스크린샷 2025-09-05 오후 7 58 17" src="https://github.com/user-attachments/assets/107e3462-690b-48c4-896f-a33799a1c14e" />

- 이미 처리된 요청에 관해서 (이미 승인 or 거절했을 경우에) 한 번 더 요청이 전송될 경우에는 오류가 발생합니다

---
## 📝 Note (주의 사항)

보내는 방식이 같다면 (알림 타입, 메시지, ... 저 GroupJoinRequestSentEvent 객체에 들어있는 것처럼... ) 
아마 한 토픽에서 처리할 수도 있을 것 같습니다 (그럼 알림 토픽에만 내용이 한 바가지 될 것 같긴 한데... 원래 그렇게 하는 거겠죠? 잘 모르겠네요) 
그럼 제가 알림 서버에서 만드는 리스너 메서드 하나로 전부 처리가 될 것 같기도 합니다! 알림을 받아서 처리하는 로직도 바로 PR 로 올리겠습니다 