### PR TITLE
✨ feat: 결제 서비스로 요청을 전송하는 서비스 로직 추가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,9 @@ dependencies {
 
 	// kafka
 	implementation 'org.springframework.kafka:spring-kafka'
+
+	// slack
+	implementation 'com.slack.api:slack-api-client:1.43.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/grow/study_service/common/util/JsonUtils.java
+++ b/src/main/java/com/grow/study_service/common/util/JsonUtils.java
@@ -27,4 +27,24 @@ public class JsonUtils {
             throw new RuntimeException("JSON 직렬화 실패", e);
         }
     }
+
+    /**
+     * 주어진 JSON 문자열을 지정된 클래스 타입으로 역직렬화합니다.
+     * 이 메서드는 Jackson의 ObjectMapper를 사용하여 JSON을 파싱하며,
+     * 제네릭 타입 T를 통해 반환 타입을 동적으로 결정합니다.
+     *
+     * @param <T> 반환될 객체의 타입 (clazz에 의해 결정됨)
+     * @param json 역직렬화할 JSON 문자열. null 또는 빈 문자열은 예외를 발생시킬 수 있음.
+     * @param clazz JSON을 매핑할 대상 클래스 타입 (예: PaymentCompletedDto.class).
+     * @return JSON 문자열이 역직렬화된 T 타입의 객체.
+     * @throws RuntimeException JSON 파싱에 실패할 경우 발생 (내부적으로 JsonProcessingException을 래핑).
+     */
+    public static <T> T fromJsonString(String json, Class<T> clazz) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.readValue(json, clazz);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("JSON 파싱 실패", e);
+        }
+    }
 }

--- a/src/main/java/com/grow/study_service/group/application/consumer/PaymentCompletedEventConsumer.java
+++ b/src/main/java/com/grow/study_service/group/application/consumer/PaymentCompletedEventConsumer.java
@@ -1,0 +1,49 @@
+package com.grow.study_service.group.application.consumer;
+
+import com.grow.study_service.common.util.JsonUtils;
+import com.grow.study_service.group.application.dto.PaymentCompletedDto;
+import com.grow.study_service.groupmember.domain.enums.Role;
+import com.grow.study_service.groupmember.domain.model.GroupMember;
+import com.grow.study_service.groupmember.domain.repository.GroupMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentCompletedEventConsumer {
+
+    private final GroupMemberRepository groupMemberRepository;
+
+    @KafkaListener(
+            topics = "payment-completed",
+            groupId = "payment-service",
+            concurrency = "3"
+    )
+    @RetryableTopic(
+            attempts = "5",
+            backoff = @Backoff(delay = 1000, multiplier = 2),
+            dltTopicSuffix = ".dlt"
+    )
+    @Transactional
+    public void consumePaymentCompleted(String message) {
+        log.info("[PAYMENT COMPLETED] 결제 완료 이벤트 수신: {}", message.trim());
+
+        PaymentCompletedDto response = JsonUtils.fromJsonString(message, PaymentCompletedDto.class);
+
+        GroupMember groupMember = GroupMember.create(
+                response.getMemberId(),
+                response.getGroupId(),
+                Role.MEMBER
+        );
+
+        groupMemberRepository.save(groupMember);
+
+        log.info("[PAYMENT COMPLETED] 결제 완료 이벤트 처리 완료: {}", JsonUtils.toJsonString(response));
+    }
+}

--- a/src/main/java/com/grow/study_service/group/application/consumer/PaymentCompletedEventDltConsumer.java
+++ b/src/main/java/com/grow/study_service/group/application/consumer/PaymentCompletedEventDltConsumer.java
@@ -1,0 +1,55 @@
+package com.grow.study_service.group.application.consumer;
+
+import com.slack.api.Slack;
+import com.slack.api.webhook.WebhookPayloads;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import static com.slack.api.model.block.Blocks.*;
+import static com.slack.api.model.block.composition.BlockCompositions.*;
+
+// 결제 완료 이벤트가 실패한 경우에 대해 처리하는 Consumer
+@Slf4j
+@Service
+public class PaymentCompletedEventDltConsumer {
+
+    @Value("${slack.webhook.url}")
+    private String slackWebhookUrl;
+
+    @KafkaListener(
+            topics = "payment-completed.dlt",
+            groupId = "payment-dlt-service"
+    )
+    public void consumePaymentCompletedDlt(String message) {
+        log.info("[PAYMENT COMPLETED DLT] 결제 완료 이벤트 실패 이벤트 수신: {}", message.trim());
+
+        // TODO 로그 시스템에 전송 or 모니터링 카운트 증가
+
+        // 슬랙으로 알림 전송
+        Slack slack = Slack.getInstance();
+
+        // 현재 시간(KST) 동적 생성
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        String currentTime = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+        // 에러 메시지 구성
+        String errorDetails = "카테고리: [GROUP]\n상세: GROUP MEMBER 등록에 실패하였습니다.\n발생 시간: " + currentTime + "\n영향: 결제 완료 후 사용자가 그룹에 포함되지 않아, 그룹 확인 지연 가능";
+
+        try {
+            slack.send(slackWebhookUrl, WebhookPayloads.payload(p -> p.blocks(asBlocks(
+                    header(h -> h.text(plainText("⚠️ 오류 알림: 멘토링 결제 완료 이벤트 수신 실패", true))),
+                    section(s -> s.text(plainText(errorDetails)))
+            ))));
+        } catch (IOException e) {
+            log.warn("[PAYMENT COMPLETED DLT] 결제 완료 이벤트 실패 이벤트 수신 실패: {}", e.getMessage());
+            throw new RuntimeException("slack 에 오류 메시지 전송 실패", e); // 뭔 오류를 던져야 됨... 참나... 귀찮게
+        }
+    }
+}

--- a/src/main/java/com/grow/study_service/group/application/dto/PaymentCompletedDto.java
+++ b/src/main/java/com/grow/study_service/group/application/dto/PaymentCompletedDto.java
@@ -1,0 +1,14 @@
+package com.grow.study_service.group.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor // JSON 역직렬화 -> 빈 생성자 반드시 필요
+@AllArgsConstructor
+public class PaymentCompletedDto {
+
+    private Long groupId; // 결제한 그룹 아이디 (멘토링 클래스의 ID)
+    private Long memberId; // 결제한 멤버의 아이디
+}

--- a/src/main/java/com/grow/study_service/group/application/event/MentoringClassPurchaseRequestedEvent.java
+++ b/src/main/java/com/grow/study_service/group/application/event/MentoringClassPurchaseRequestedEvent.java
@@ -1,0 +1,16 @@
+package com.grow.study_service.group.application.event;
+
+import com.grow.study_service.group.domain.enums.Category;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MentoringClassPurchaseRequestedEvent {
+
+    private final Long groupId; // 결제 대상 ID
+    private final Long memberId; // 결제할 멤버의 ID
+    private final Category category; // 결제 대상 카테고리
+    private final String groupName; // 결제 대상 이름
+    private final int amount; // 결제 금액
+}


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인

+ 📸 Screenshot or Test Result

<img width="1055" height="509" alt="스크린샷 2025-09-06 오후 5 17 09" src="https://github.com/user-attachments/assets/4c16014c-414e-4d8f-b199-263ed5050975" />
<img width="597" height="79" alt="스크린샷 2025-09-06 오후 5 17 24" src="https://github.com/user-attachments/assets/33358830-fd99-4957-9179-169da0f4ad8b" />

- 결제 완료 이벤트 정상 수신 시
- DB 에 새로운 멤버가 저장됨을 확인

<img width="462" height="181" alt="스크린샷 2025-09-06 오후 7 21 23" src="https://github.com/user-attachments/assets/06c4a7b3-18ab-41a7-a395-d3ab069a8b70" />

- 결제 완료 이벤트를 제대로 수신하지 못하여 재시도 실행 -> 최종 실패 시 슬랙으로 알림 전송합니다 (TODO의 내용은 구현해야 합니다)

## 📝 Note (주의 사항)
1. 병렬 처리를 위해서 파티션을 여러 개 생성하고, 하나의 서버에서 여러 파티션 (최대 3개) 을 수신할 수 있도록 구현했습니다 -> 멀티 스레드 이용
2. 결제 서버에서 내용을 조합해 결제한 다음, 결제 완료 이벤트를 전송할 경우 이를 수신하여 그룹에 결제한 사용자를 추가합니다
3. 제네릭 타입 야무지게 써먹었습니다 감사합니다