### PR TITLE
✨ feat: 대시보드 구성 API 구현 - 한줄 공지 / 출석률 증가 및 조회 #48

### DIFF
--- a/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
+++ b/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     GROUP_ALREADY_JOINED("409", "이미 가입된 그룹입니다."),
     JOIN_REQUEST_ALREADY_SENT("409", "이미 가입 요청을 보냈습니다." ),
     NO_PERMISSION_TO_ACCEPT_REQUEST("403", "요청을 수락할 권한이 없습니다."),
-    JOIN_REQUEST_NOT_FOUND("404", "해당 그룹에 참여 요청이 전송되지 않았습니다." ),
+    JOIN_REQUEST_NOT_FOUND("404", "해당 그룹에 참여 요청이 전송되지 않았습니다."),
+    INVALID_DATE_RANGE("400", "시작 날짜는 종료 날짜보다 미래일 수 없습니다."),
 
     /**
      * 📌 2. 그룹 멤버(Group Member) 관련

--- a/src/main/java/com/grow/study_service/common/init/DataInit.java
+++ b/src/main/java/com/grow/study_service/common/init/DataInit.java
@@ -11,15 +11,17 @@ import com.grow.study_service.group.domain.repository.GroupRepository;
 import com.grow.study_service.groupmember.domain.enums.Role;
 import com.grow.study_service.groupmember.domain.model.GroupMember;
 import com.grow.study_service.groupmember.domain.repository.GroupMemberRepository;
+import com.grow.study_service.notice.domain.model.Notice;
+import com.grow.study_service.notice.domain.repository.NoticeRepository;
 import com.grow.study_service.post.domain.model.Post;
 import com.grow.study_service.post.domain.repository.PostRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,6 +35,7 @@ public class DataInit implements CommandLineRunner {
     private final PostRepository postRepository;
     private final BoardRepository boardRepository;
     private final RedisConnectionFactory redisConnectionFactory;
+    private final NoticeRepository noticeRepository;
 
     @Override
     public void run(String... args) throws Exception {
@@ -45,31 +48,31 @@ public class DataInit implements CommandLineRunner {
         // ------- 그룹 생성 ------- //
 
         // STUDY 카테고리: 7개
-        groups.add(Group.create("자바 프로그래밍 스터디", Category.STUDY, "자바 초보자들을 위한 실습 중심 스터디 그룹입니다.", PersonalityTag.DILIGENT, SkillTag.JAVA_PROGRAMMING, 0));
-        groups.add(Group.create("영어 회화 모임", Category.STUDY, "매일 영어 대화를 연습하며 실력을 키우는 학습 커뮤니티.", PersonalityTag.ACTIVE, SkillTag.ENGLISH_CONVERSATION, 0));
-        groups.add(Group.create("데이터 사이언스 학습단", Category.STUDY, "파이썬과 머신러닝을 함께 공부하는 열정적인 그룹.", PersonalityTag.CREATIVE, SkillTag.PYTHON_DATA_SCIENCE, 0));
-        groups.add(Group.create("역사 탐구 클럽", Category.STUDY, "고대 역사부터 현대사까지 깊이 있게 탐구합니다.", PersonalityTag.METICULOUS, SkillTag.HISTORY_EXPLORATION, 0));
+        groups.add(Group.create("자바 프로그래밍 스터디", Category.STUDY, "자바 초보자들을 위한 실습 중심 스터디 그룹입니다.", PersonalityTag.DILIGENT, SkillTag.JAVA_PROGRAMMING, 0, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("영어 회화 모임", Category.STUDY, "매일 영어 대화를 연습하며 실력을 키우는 학습 커뮤니티.", PersonalityTag.ACTIVE, SkillTag.ENGLISH_CONVERSATION, 0, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("데이터 사이언스 학습단", Category.STUDY, "파이썬과 머신러닝을 함께 공부하는 열정적인 그룹.", PersonalityTag.CREATIVE, SkillTag.PYTHON_DATA_SCIENCE, 0, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("역사 탐구 클럽", Category.STUDY, "고대 역사부터 현대사까지 깊이 있게 탐구합니다.", PersonalityTag.METICULOUS, SkillTag.HISTORY_EXPLORATION, 0, LocalDateTime.now().plusMonths(1)));
         // groups.add(Group.create("수학 문제 풀이 그룹", Category.STUDY, "고등 수학 문제를 함께 풀며 논리력을 강화하세요.", PersonalityTag.ANALYTICAL, SkillTag.MATH_PROBLEM_SOLVING, 0));
         // groups.add(Group.create("프랑스어 배우기", Category.STUDY, "기초부터 고급까지 프랑스어를 재미있게 배우는 모임.", PersonalityTag.PATIENT, SkillTag.FRENCH_LANGUAGE, 0));
         // groups.add(Group.create("경제학 세미나", Category.STUDY, "경제 이론과 실생활 사례를 논의하는 지적 토론 그룹.", PersonalityTag.COLLABORATIVE, SkillTag.ECONOMICS, 0));
 
         // HOBBY 카테고리: 7개
-        groups.add(Group.create("등산 동호회", Category.HOBBY, "주말마다 산을 오르며 자연을 즐기는 취미 모임.", PersonalityTag.ADVENTUROUS, SkillTag.HIKING, 0));
-        groups.add(Group.create("요리 마스터 클럽", Category.HOBBY, "다양한 요리 레시피를 공유하고 함께 만드는 재미있는 그룹.", PersonalityTag.CREATIVE, SkillTag.COOKING, 0));
-        groups.add(Group.create("기타 연주 모임", Category.HOBBY, "초보자부터 프로까지 기타를 치며 음악을 즐깁니다.", PersonalityTag.PASSIONATE, SkillTag.GUITAR_PLAYING, 0));
-        groups.add(Group.create("사진 촬영 여행단", Category.HOBBY, "카메라를 들고 여행하며 아름다운 순간을 담아요.", PersonalityTag.VIBRANT, SkillTag.PHOTOGRAPHY, 0));
-        groups.add(Group.create("독서 모임", Category.HOBBY, "매월 한 권의 책을 읽고 토론하는 문화 취미 그룹.", PersonalityTag.EMPATHETIC, SkillTag.BOOK_READING, 0));
-        groups.add(Group.create("원예 가드닝 클럽", Category.HOBBY, "집에서 식물을 키우며 여유로운 시간을 보내는 모임.", PersonalityTag.CALM, SkillTag.GARDENING, 0));
-        groups.add(Group.create("보드게임 파티", Category.HOBBY, "다양한 보드게임을 즐기며 친구를 사귀는 재미난 그룹.", PersonalityTag.HUMOROUS, SkillTag.BOARD_GAMES, 0));
+        groups.add(Group.create("등산 동호회", Category.HOBBY, "주말마다 산을 오르며 자연을 즐기는 취미 모임.", PersonalityTag.ADVENTUROUS, SkillTag.HIKING, 0, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("요리 마스터 클럽", Category.HOBBY, "다양한 요리 레시피를 공유하고 함께 만드는 재미있는 그룹.", PersonalityTag.CREATIVE, SkillTag.COOKING, 0, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("기타 연주 모임", Category.HOBBY, "초보자부터 프로까지 기타를 치며 음악을 즐깁니다.", PersonalityTag.PASSIONATE, SkillTag.GUITAR_PLAYING, 0, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("사진 촬영 여행단", Category.HOBBY, "카메라를 들고 여행하며 아름다운 순간을 담아요.", PersonalityTag.VIBRANT, SkillTag.PHOTOGRAPHY, 0, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("독서 모임", Category.HOBBY, "매월 한 권의 책을 읽고 토론하는 문화 취미 그룹.", PersonalityTag.EMPATHETIC, SkillTag.BOOK_READING, 0, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("원예 가드닝 클럽", Category.HOBBY, "집에서 식물을 키우며 여유로운 시간을 보내는 모임.", PersonalityTag.CALM, SkillTag.GARDENING, 0, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("보드게임 파티", Category.HOBBY, "다양한 보드게임을 즐기며 친구를 사귀는 재미난 그룹.", PersonalityTag.HUMOROUS, SkillTag.BOARD_GAMES, 0, LocalDateTime.now().plusMonths(1)));
 
         // MENTORING 카테고리: 7개
-        groups.add(Group.create("커리어 멘토링 그룹", Category.MENTORING, "경력 개발을 위한 선배들의 조언을 공유하는 멘토링 모임.", PersonalityTag.SUPPORTIVE, SkillTag.CAREER_COACHING, 10000));
-        groups.add(Group.create("스타트업 창업 가이드", Category.MENTORING, "창업 아이디어를 실현하기 위한 실전 멘토링 세션.", PersonalityTag.INNOVATIVE, SkillTag.STARTUP_GUIDANCE, 20000));
-        groups.add(Group.create("리더십 코칭 클럽", Category.MENTORING, "리더십 스킬을 키우는 개인화된 멘토링 프로그램.", PersonalityTag.CHARISMATIC, SkillTag.LEADERSHIP_COACHING, 80000));
-        groups.add(Group.create("IT 취업 준비단", Category.MENTORING, "IT 분야 취업을 위한 이력서 작성과 인터뷰 팁 공유.", PersonalityTag.DISCIPLINED, SkillTag.IT_JOB_PREPARATION, 120000));
-        groups.add(Group.create("예술가 멘토링 네트워크", Category.MENTORING, "예술 창작자들을 위한 영감과 피드백 멘토링.", PersonalityTag.INSPIRING, SkillTag.ART_MENTORING, 30000));
-        groups.add(Group.create("금융 투자 조언 모임", Category.MENTORING, "투자 초보자를 위한 전문가 멘토링 그룹.", PersonalityTag.ANALYTICAL, SkillTag.FINANCIAL_INVESTMENT, 40000));
-        groups.add(Group.create("건강 관리 코칭", Category.MENTORING, "건강한 생활 습관을 위한 개인 멘토링과 조언.", PersonalityTag.RESILIENT, SkillTag.HEALTH_COACHING, 50000));
+        groups.add(Group.create("커리어 멘토링 그룹", Category.MENTORING, "경력 개발을 위한 선배들의 조언을 공유하는 멘토링 모임.", PersonalityTag.SUPPORTIVE, SkillTag.CAREER_COACHING, 10000, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("스타트업 창업 가이드", Category.MENTORING, "창업 아이디어를 실현하기 위한 실전 멘토링 세션.", PersonalityTag.INNOVATIVE, SkillTag.STARTUP_GUIDANCE, 20000, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("리더십 코칭 클럽", Category.MENTORING, "리더십 스킬을 키우는 개인화된 멘토링 프로그램.", PersonalityTag.CHARISMATIC, SkillTag.LEADERSHIP_COACHING, 80000, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("IT 취업 준비단", Category.MENTORING, "IT 분야 취업을 위한 이력서 작성과 인터뷰 팁 공유.", PersonalityTag.DISCIPLINED, SkillTag.IT_JOB_PREPARATION, 120000, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("예술가 멘토링 네트워크", Category.MENTORING, "예술 창작자들을 위한 영감과 피드백 멘토링.", PersonalityTag.INSPIRING, SkillTag.ART_MENTORING, 30000, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("금융 투자 조언 모임", Category.MENTORING, "투자 초보자를 위한 전문가 멘토링 그룹.", PersonalityTag.ANALYTICAL, SkillTag.FINANCIAL_INVESTMENT, 40000, LocalDateTime.now().plusMonths(1)));
+        groups.add(Group.create("건강 관리 코칭", Category.MENTORING, "건강한 생활 습관을 위한 개인 멘토링과 조언.", PersonalityTag.RESILIENT, SkillTag.HEALTH_COACHING, 50000, LocalDateTime.now().plusMonths(1)));
 
         groups.forEach(groupRepository::save);
 
@@ -143,6 +146,15 @@ public class DataInit implements CommandLineRunner {
         postRepository.save(post1);
         postRepository.save(post2);
         postRepository.save(post3);
+
+        // ------- Notice 초기화 추가: groupId 1로 여러 공지사항 생성, 하나만 isPinned true ------- //
+        List<Notice> notices = new ArrayList<>();
+        notices.add(Notice.create(1L, "환영 공지 - 그룹에 오신 것을 환영합니다!", false));  // isPinned false
+        notices.add(Notice.create(1L, "중요 공지 - 이번 주 모임 안내입니다.", true));     // isPinned true (하나만 true)
+        notices.add(Notice.create(1L, "일반 공지 1 - 스터디 규칙을 확인하세요.", false)); // isPinned false
+        notices.add(Notice.create(1L, "일반 공지 2 - 자료 공유 안내.", false));          // isPinned false
+
+        notices.forEach(noticeRepository::save);  // NoticeRepository로 저장
 
         log.info("Data init completed.");
     }

--- a/src/main/java/com/grow/study_service/dashboard/application/DashboardService.java
+++ b/src/main/java/com/grow/study_service/dashboard/application/DashboardService.java
@@ -2,4 +2,5 @@ package com.grow.study_service.dashboard.application;
 
 public interface DashboardService {
     void incrementAttendanceDays(Long groupId, Long memberId);
+    Double getAttendanceRate(Long groupId, Long memberId);
 }

--- a/src/main/java/com/grow/study_service/dashboard/application/DashboardService.java
+++ b/src/main/java/com/grow/study_service/dashboard/application/DashboardService.java
@@ -1,0 +1,5 @@
+package com.grow.study_service.dashboard.application;
+
+public interface DashboardService {
+    void incrementAttendanceDays(Long groupId, Long memberId);
+}

--- a/src/main/java/com/grow/study_service/dashboard/application/impl/DashboardServiceImpl.java
+++ b/src/main/java/com/grow/study_service/dashboard/application/impl/DashboardServiceImpl.java
@@ -1,0 +1,45 @@
+package com.grow.study_service.dashboard.application.impl;
+
+import com.grow.study_service.common.exception.ErrorCode;
+import com.grow.study_service.common.exception.domain.DomainException;
+import com.grow.study_service.dashboard.application.DashboardService;
+import com.grow.study_service.groupmember.domain.model.GroupMember;
+import com.grow.study_service.groupmember.domain.repository.GroupMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DashboardServiceImpl implements DashboardService {
+
+    private final GroupMemberRepository groupMemberRepository;
+
+    /**
+     * 주어진 그룹 ID와 멤버 ID에 해당하는 멤버의 누적 출석 일수를 증가시킵니다.
+     *
+     * @param groupId 그룹 ID (검증용)
+     * @param memberId 멤버 ID
+     * @throws DomainException 멤버가 존재하지 않거나 그룹에 속하지 않을 경우
+     */
+    @Override
+    @Transactional
+    public void incrementAttendanceDays(Long groupId, Long memberId) {
+        GroupMember findMember = groupMemberRepository.findById(memberId).orElseThrow(() ->
+                new DomainException(ErrorCode.GROUP_MEMBER_NOT_FOUND));
+
+        log.info("[DASHBOARD][ATTENDANCE][START] 그룹 {}의 멤버 {}의 출석일을 누적 시작, 현재 출석일={}",
+                groupId, memberId, findMember.getTotalAttendanceDays());
+
+        // 도메인 로직 호출: 출석 일수 누적 업데이트 (반환값으로 업데이트된 도메인 객체 받음)
+        // 반환값이 필요는 없으나, 로그에서 편하게 확인하기 위해서 반환값 사용
+        GroupMember updated = findMember.incrementAttendanceDays();
+
+        groupMemberRepository.save(updated);
+
+        log.info("[DASHBOARD][ATTENDANCE][END] 그룹 {}의 멤버 {}의 출석일을 누적 완료, 현재 출석일={}",
+                groupId, memberId, updated.getTotalAttendanceDays());
+    }
+}

--- a/src/main/java/com/grow/study_service/dashboard/application/impl/DashboardServiceImpl.java
+++ b/src/main/java/com/grow/study_service/dashboard/application/impl/DashboardServiceImpl.java
@@ -34,7 +34,7 @@ public class DashboardServiceImpl implements DashboardService {
     @Transactional
     public void incrementAttendanceDays(Long groupId, Long memberId) {
         GroupMember findMember = groupMemberRepository.findById(memberId).orElseThrow(() ->
-                new DomainException(ErrorCode.GROUP_MEMBER_NOT_FOUND));
+                new ServiceException(ErrorCode.GROUP_MEMBER_NOT_FOUND));
 
         log.info("[DASHBOARD][ATTENDANCE][START] 그룹 {}의 멤버 {}의 출석일을 누적 시작, 현재 출석일={}",
                 groupId, memberId, findMember.getTotalAttendanceDays());

--- a/src/main/java/com/grow/study_service/dashboard/application/impl/DashboardServiceImpl.java
+++ b/src/main/java/com/grow/study_service/dashboard/application/impl/DashboardServiceImpl.java
@@ -71,11 +71,8 @@ public class DashboardServiceImpl implements DashboardService {
 
         LocalDateTime start = group.getStartAt();  // 시작일
         LocalDateTime end = group.getEndAt();      // 종료일
-        int totalAttendanceDays = groupMember.getTotalAttendanceDays(); // 총 출석 일수
 
         double totalDays = group.calculateTotalAttendanceDays(start, end); // 총 일수 계산 (시작일 포함)
-        double rate = (totalAttendanceDays / totalDays) * 100;
-
-        return Math.round(rate * 10) / 10.0;
+        return groupMember.calculateTotalAttendanceRate(totalDays); // 총 출석률 계산 (시작일 포함)
     }
 }

--- a/src/main/java/com/grow/study_service/dashboard/application/impl/DashboardServiceImpl.java
+++ b/src/main/java/com/grow/study_service/dashboard/application/impl/DashboardServiceImpl.java
@@ -2,7 +2,10 @@ package com.grow.study_service.dashboard.application.impl;
 
 import com.grow.study_service.common.exception.ErrorCode;
 import com.grow.study_service.common.exception.domain.DomainException;
+import com.grow.study_service.common.exception.service.ServiceException;
 import com.grow.study_service.dashboard.application.DashboardService;
+import com.grow.study_service.group.domain.model.Group;
+import com.grow.study_service.group.domain.repository.GroupRepository;
 import com.grow.study_service.groupmember.domain.model.GroupMember;
 import com.grow.study_service.groupmember.domain.repository.GroupMemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,12 +13,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class DashboardServiceImpl implements DashboardService {
 
     private final GroupMemberRepository groupMemberRepository;
+    private final GroupRepository groupRepository;
 
     /**
      * 주어진 그룹 ID와 멤버 ID에 해당하는 멤버의 누적 출석 일수를 증가시킵니다.
@@ -41,5 +47,35 @@ public class DashboardServiceImpl implements DashboardService {
 
         log.info("[DASHBOARD][ATTENDANCE][END] 그룹 {}의 멤버 {}의 출석일을 누적 완료, 현재 출석일={}",
                 groupId, memberId, updated.getTotalAttendanceDays());
+    }
+
+    /**
+     * 그룹과 멤버의 출석 정보를 이용해 출석률을 계산합니다.
+     * 출석률 = (member.totalAttendanceDays / 총 기간(일)) * 100
+     *
+     * @param groupId  그룹 ID
+     * @param memberId 멤버 ID
+     * @return 출석률(퍼센트)
+     * @throws ServiceException 그룹/멤버 없음
+     * @throws DomainException  날짜 범위 오류 시
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Double getAttendanceRate(Long groupId, Long memberId) {
+        // 유지보수를 위해서 전체 조회를 기본으로 -> 성능 병목이 생길 경우에는 부분 조회로 변경 (유지보수성과 성능의 트레이드오프로 결정)
+        Group group = groupRepository.findById(groupId).orElseThrow(() ->
+                new ServiceException(ErrorCode.GROUP_NOT_FOUND));
+
+        GroupMember groupMember = groupMemberRepository.findById(memberId).orElseThrow(() ->
+                new ServiceException(ErrorCode.GROUP_MEMBER_NOT_FOUND));
+
+        LocalDateTime start = group.getStartAt();  // 시작일
+        LocalDateTime end = group.getEndAt();      // 종료일
+        int totalAttendanceDays = groupMember.getTotalAttendanceDays(); // 총 출석 일수
+
+        double totalDays = group.calculateTotalAttendanceDays(start, end); // 총 일수 계산 (시작일 포함)
+        double rate = (totalAttendanceDays / totalDays) * 100;
+
+        return Math.round(rate * 10) / 10.0;
     }
 }

--- a/src/main/java/com/grow/study_service/dashboard/presentation/DashboardController.java
+++ b/src/main/java/com/grow/study_service/dashboard/presentation/DashboardController.java
@@ -1,0 +1,45 @@
+package com.grow.study_service.dashboard.presentation;
+
+import com.grow.study_service.common.rsdata.RsData;
+import com.grow.study_service.dashboard.application.DashboardService;
+import com.grow.study_service.notice.application.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/dashboard")
+public class DashboardController {
+
+    private final NoticeService noticeService;
+    private final DashboardService dashboardService;
+
+    // 대시보드에 입장 -> 그룹의 출석률을 올려 줄 수 있도록 하는 API
+    @PostMapping("/update-rate/{groupId}")
+    public RsData<Void> incrementAttendanceDays(@RequestHeader("X-Authorization-Id") Long memberId,
+                                                @PathVariable("groupId") Long groupId) {
+
+        dashboardService.incrementAttendanceDays(groupId, memberId);
+
+        return new RsData<>(
+                "200",
+                "출석일 업데이트 완료"
+        );
+    }
+
+    // 대시보드에서 한줄 공지 보여주는 API
+    @GetMapping("/notice-pinned/{groupId}")
+    public RsData<String> getNoticePinned(@RequestHeader("X-Authorization-Id") Long memberId,
+                                          @PathVariable("groupId") Long groupId) {
+
+        String pinnedNotice = noticeService.getPinnedNotice(groupId);
+
+        return new RsData<>(
+                "200",
+                "공지사항 조회 완료",
+                pinnedNotice
+        );
+    }
+
+    // 내 출석률 체크하여 보여 주는 API
+}

--- a/src/main/java/com/grow/study_service/dashboard/presentation/DashboardController.java
+++ b/src/main/java/com/grow/study_service/dashboard/presentation/DashboardController.java
@@ -42,4 +42,16 @@ public class DashboardController {
     }
 
     // 내 출석률 체크하여 보여 주는 API
+    @GetMapping("/attendance-rate/{groupId}")
+    public RsData<Double> getAttendanceRate(@RequestHeader("X-Authorization-Id") Long memberId,
+                                            @PathVariable("groupId") Long groupId) {
+
+        Double attendanceRate = dashboardService.getAttendanceRate(groupId, memberId);
+
+        return new RsData<>(
+                "200",
+                "출석률 조회 완료",
+                attendanceRate
+        );
+    }
 }

--- a/src/main/java/com/grow/study_service/group/domain/model/Group.java
+++ b/src/main/java/com/grow/study_service/group/domain/model/Group.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import com.grow.study_service.group.domain.enums.Category;
 
@@ -195,5 +196,18 @@ public class Group {
         this.viewCount++;
 
         return this;
+    }
+
+    // 총 일수 계산: ChronoUnit 으로 일 단위 차이 (시작일 포함 위해 +1)
+    public double calculateTotalAttendanceDays(LocalDateTime start, LocalDateTime end) {
+        long totalDays = ChronoUnit.DAYS.between(start.toLocalDate(), end.toLocalDate()) + 1;
+
+        if (totalDays <= 0) {
+            // 유효성 검사 (end < start 방지)
+            throw new DomainException(ErrorCode.INVALID_DATE_RANGE);
+        }
+
+        // 소수점 첫째 자리까지만 반올림
+        return Math.round(totalDays * 10) / 10.0;
     }
 }

--- a/src/main/java/com/grow/study_service/group/domain/model/Group.java
+++ b/src/main/java/com/grow/study_service/group/domain/model/Group.java
@@ -37,7 +37,12 @@ public class Group {
     /**
      * 그룹이 생성된 날짜와 시간. 생성 시점에 설정되며, 변경되지 않습니다.
      */
-    private final LocalDateTime createdAt;
+    private final LocalDateTime startAt;
+
+    /**
+     * 그룹의 종료 날짜와 시간. 그룹이 종료되기 전까지 유효합니다.
+     */
+    private final LocalDateTime endAt;
 
     /**
      * 그룹의 이름. 업데이트 가능하며, 비어 있지 않아야 합니다.
@@ -69,7 +74,7 @@ public class Group {
      */
     private SkillTag skillTag;
 
-    // TODO 기간 추가
+
 
     private Long version; // 낙관적 락
 
@@ -88,13 +93,15 @@ public class Group {
                                String description,
                                PersonalityTag personalityTag,
                                SkillTag skillTag,
-                               int amount) {
+                               int amount,
+                               LocalDateTime endAt) {
 
         verifyParameters(name, category, description);
         return new Group(
                 null, // 자동 생성
                 category,
                 LocalDateTime.now(), // 데이터베이스에 저장될 때는 현재 시각을 사용함.
+                endAt,
                 name,
                 description,
                 amount,
@@ -125,24 +132,26 @@ public class Group {
      * @param name        그룹 이름.
      * @param category    그룹 카테고리.
      * @param description 그룹 설명.
-     * @param createdAt   그룹 생성 시각.
+     * @param startAt   그룹 생성 시각.
+     * @param endAt 그룹의 종료 시각.
      * @return 조회된 정보를 담은 Group 인스턴스.
      */
     public static Group of(Long groupId,
                            String name,
                            Category category,
                            String description,
-                           LocalDateTime createdAt,
                            int amount,
                            int viewCount,
                            PersonalityTag personalityTag,
                            SkillTag skillTag,
+                           LocalDateTime startAt,
+                           LocalDateTime endAt,
                            Long version) {
 
         return new Group(
                 groupId, category,
-                createdAt, name,
-                description, amount,
+                startAt, endAt,
+                name, description, amount,
                 viewCount, personalityTag,
                 skillTag, version);
     }

--- a/src/main/java/com/grow/study_service/group/infra/persistence/entity/GroupJpaEntity.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/entity/GroupJpaEntity.java
@@ -29,8 +29,6 @@ public class GroupJpaEntity {
 	@Column(columnDefinition = "TEXT")
 	private String description;
 
-	private LocalDateTime createdAt;
-
 	private int amount; // 멘토링 설정 값 (다른 항목에선 0 유지)
 
 	private int viewCount; // 조회수
@@ -40,6 +38,10 @@ public class GroupJpaEntity {
 
 	@Enumerated(EnumType.STRING)
 	private SkillTag skillTag;
+
+	private LocalDateTime startAt; // 시작 날짜
+
+	private LocalDateTime endAt; // 종료 날짜
 
 	@Version
 	private Long version; // 낙관적 락

--- a/src/main/java/com/grow/study_service/group/infra/persistence/mapper/GroupMapper.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/mapper/GroupMapper.java
@@ -29,11 +29,12 @@ public class GroupMapper {
 				entity.getName(),
 				entity.getCategory(),
 				entity.getDescription(),
-				entity.getCreatedAt(),
 				entity.getAmount(),
 				entity.getViewCount(),
 				entity.getPersonalityTag(),
 				entity.getSkillTag(),
+				entity.getStartAt(),
+				entity.getEndAt(),
 				entity.getVersion()
 		);
 	}
@@ -51,7 +52,8 @@ public class GroupMapper {
 				.name(group.getName())
 				.category(group.getCategory())
 				.description(group.getDescription())
-				.createdAt(group.getCreatedAt())
+				.startAt(group.getStartAt())
+				.endAt(group.getEndAt())
 				.amount(group.getAmount())
 				.personalityTag(group.getPersonalityTag())
 				.viewCount(group.getViewCount())

--- a/src/main/java/com/grow/study_service/groupmember/domain/model/GroupMember.java
+++ b/src/main/java/com/grow/study_service/groupmember/domain/model/GroupMember.java
@@ -202,4 +202,15 @@ public class GroupMember {
         this.totalAttendanceDays++;
         return this;
     }
+
+    /**
+     * 출석률 계산 메서드
+     *
+     * @param totalDays 출석일 수 (총 출석일 수)
+     * @return 출석률 (0 ~ 100), 소수점 첫 자리에서 반올림.
+     */
+    public Double calculateTotalAttendanceRate(double totalDays) {
+        double rate = (this.totalAttendanceDays / totalDays) * 100;
+        return Math.round(rate * 10) / 10.0;
+    }
 }

--- a/src/main/java/com/grow/study_service/groupmember/domain/model/GroupMember.java
+++ b/src/main/java/com/grow/study_service/groupmember/domain/model/GroupMember.java
@@ -47,6 +47,8 @@ public class GroupMember {
 	 */
 	private final LocalDateTime joinedAt;
 
+    private int totalAttendanceDays; // 누적 출석일 카운트
+
     private Long version;
 
     /**
@@ -71,6 +73,7 @@ public class GroupMember {
                 groupId,
                 role,
                 LocalDateTime.now(), // 데이터베이스에 저장될 때는 현재 시각을 사용함. (자동 생성)
+                0,
                 null // 버전 자동 생성
         );
     }
@@ -92,6 +95,7 @@ public class GroupMember {
                                  Long groupId,
                                  Role role,
                                  LocalDateTime joinedAt,
+                                 int totalAttendanceDays,
                                  Long version) {
 
         verifyParameters(memberId, groupId, role);
@@ -103,6 +107,7 @@ public class GroupMember {
                 groupId,
                 role,
                 joinedAt,
+                totalAttendanceDays,
                 version
         );
     }
@@ -188,5 +193,13 @@ public class GroupMember {
         if (role != Role.LEADER) {
             throw new DomainException(ErrorCode.GROUP_LEADER_REQUIRED);
         }
+    }
+
+    /**
+     * 출석일 증가 메서드
+     */
+    public GroupMember incrementAttendanceDays() {
+        this.totalAttendanceDays++;
+        return this;
     }
 }

--- a/src/main/java/com/grow/study_service/groupmember/infra/persistence/entity/GroupMemberJpaEntity.java
+++ b/src/main/java/com/grow/study_service/groupmember/infra/persistence/entity/GroupMemberJpaEntity.java
@@ -31,6 +31,8 @@ public class GroupMemberJpaEntity {
 
 	private LocalDateTime joinedAt;
 
+	private int totalAttendanceDays; // 누적 출석일 카운트
+
 	@Version
 	private Long version;
 }

--- a/src/main/java/com/grow/study_service/groupmember/infra/persistence/mapper/GroupMemberMapper.java
+++ b/src/main/java/com/grow/study_service/groupmember/infra/persistence/mapper/GroupMemberMapper.java
@@ -31,6 +31,7 @@ public class GroupMemberMapper {
 				entity.getGroupId(),
 				entity.getRole(),
 				entity.getJoinedAt(),
+				entity.getTotalAttendanceDays(),
 				entity.getVersion()
 		);
 	}
@@ -51,6 +52,7 @@ public class GroupMemberMapper {
 				.groupId(domain.getGroupId())
 				.role(domain.getRole())
 				.joinedAt(domain.getJoinedAt())
+				.totalAttendanceDays(domain.getTotalAttendanceDays())
 				.version(domain.getVersion());
 
 		if (domain.getGroupId() != null) {

--- a/src/main/java/com/grow/study_service/notice/application/service/NoticeService.java
+++ b/src/main/java/com/grow/study_service/notice/application/service/NoticeService.java
@@ -11,4 +11,5 @@ public interface NoticeService {
     void updateNotices(Long groupId, Long memberId, List<NoticeUpdateRequest> request);
     List<NoticeResponse> getNotices(Long groupId, Long memberId);
     void deleteNotice(Long groupId, Long noticeId, Long memberId);
+    String getPinnedNotice(Long groupId);
 }

--- a/src/main/java/com/grow/study_service/notice/application/service/NoticeServiceImpl.java
+++ b/src/main/java/com/grow/study_service/notice/application/service/NoticeServiceImpl.java
@@ -194,6 +194,21 @@ public class NoticeServiceImpl implements NoticeService {
     }
 
     /**
+     * 주어진 그룹 ID에 해당하는 고정된 공지사항의 내용을 가져옵니다.
+     * 대시보드에서 한 줄 공지로 보여주기 위한 용도입니다.
+     * 고정된 공지사항이 없을 경우 null을 반환합니다.
+     *
+     * @param groupId 조회할 그룹 ID
+     * @return 고정된 공지사항의 내용 (String), 없으면 null
+     */
+    @Override
+    public String getPinnedNotice(Long groupId) {
+        return noticeRepository.findByIsPinnedTrue(groupId)
+                .map(Notice::getContent)
+                .orElse(null); // 고정된 공지사항이 없으면 null 반환
+    }
+
+    /**
      * 지정된 그룹에서 해당 회원이 그룹장 권한을 가지고 있는지 검증한다.
      * <p>
      * 1. 멤버 ID와 그룹 ID로 그룹 멤버 정보를 조회

--- a/src/main/java/com/grow/study_service/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/com/grow/study_service/notice/domain/repository/NoticeRepository.java
@@ -10,5 +10,6 @@ public interface NoticeRepository {
     void saveAll(List<Notice> notices);
     Optional<Notice> findByNoticeId(Long noticeId);
     List<Notice> findByGroupId(Long groupId);
+    Optional<Notice> findByIsPinnedTrue(Long groupId);
     void deleteById(Long noticeId);
 }

--- a/src/main/java/com/grow/study_service/notice/infra/repository/NoticeJpaRepository.java
+++ b/src/main/java/com/grow/study_service/notice/infra/repository/NoticeJpaRepository.java
@@ -1,10 +1,23 @@
 package com.grow.study_service.notice.infra.repository;
 
 import com.grow.study_service.notice.infra.entity.NoticeJpaEntity;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface NoticeJpaRepository extends JpaRepository<NoticeJpaEntity, Long> {
     List<NoticeJpaEntity> findByGroupId(Long groupId);
+
+    /**
+     * 주어진 그룹 ID에 속하고 고정된(isPinned=true) 공지사항 목록을 조회합니다.
+     *
+     * @param groupId 조회할 그룹 ID
+     * @return 해당 조건을 만족하는 NoticeJpaEntity 목록 (결과가 없을 경우 빈 리스트 반환)
+     */
+    @Query("select n from NoticeJpaEntity n " +
+            "where n.groupId = :groupId and n.isPinned = true")
+    List<NoticeJpaEntity> findByGroupIdAndPinnedIsTrue(@Param("groupId") Long groupId);
+
 }

--- a/src/main/java/com/grow/study_service/notice/infra/repository/NoticeRepositoryImpl.java
+++ b/src/main/java/com/grow/study_service/notice/infra/repository/NoticeRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.grow.study_service.notice.domain.model.Notice;
 import com.grow.study_service.notice.domain.repository.NoticeRepository;
 import com.grow.study_service.notice.infra.entity.NoticeJpaEntity;
 import com.grow.study_service.notice.infra.mapper.NoticeMapper;
-import com.grow.study_service.notice.presentation.dto.NoticeResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -63,6 +62,14 @@ public class NoticeRepositoryImpl implements NoticeRepository {
                 .map(mapper::toDomain)
                 .toList();
         return list;
+    }
+
+    @Override
+    public Optional<Notice> findByIsPinnedTrue(Long groupId) {
+        return noticeJpaRepository.findByGroupIdAndPinnedIsTrue(groupId)
+                .stream()
+                .map(mapper::toDomain)
+                .findFirst();
     }
 
     @Override


### PR DESCRIPTION
## ✅ Check List(필수)
- [X] 코드에 주석 추가 완료
- [X] 테스트 통과 확인

+ 📸 Screenshot or Test Result

<img width="838" height="149" alt="스크린샷 2025-09-08 오후 8 33 39" src="https://github.com/user-attachments/assets/ab591bd9-0f30-44a5-8b4a-34be8f8f497d" />
<img width="795" height="90" alt="스크린샷 2025-09-08 오후 8 33 46" src="https://github.com/user-attachments/assets/9dac9ddd-cdd8-4e61-b7df-5cb3b496e1bb" />

- 출석 증가 로그 확인

<img width="698" height="85" alt="스크린샷 2025-09-08 오후 8 34 17" src="https://github.com/user-attachments/assets/10ac2e88-d5db-44c8-b6e5-8b12bfc1bb73" />

- DB에 2일로 누적 출석일이 반영됨

<img width="474" height="167" alt="스크린샷 2025-09-08 오후 8 48 14" src="https://github.com/user-attachments/assets/7559874d-9466-42ea-8aa3-301936535858" />
<img width="798" height="516" alt="스크린샷 2025-09-08 오후 8 49 28" src="https://github.com/user-attachments/assets/b70f4e0d-f447-455c-8459-5cf4f0a4947e" />

- 사전 DB에 값을 미리 세팅해 두고, 포스트맨으로 조회
- 핀으로 고정된 것이 아니면 조회되지 않음


<img width="834" height="474" alt="스크린샷 2025-09-08 오후 9 29 36" src="https://github.com/user-attachments/assets/94cab0af-4f71-4665-af4f-295f0f1c3e36" />
<img width="844" height="427" alt="스크린샷 2025-09-08 오후 9 24 38" src="https://github.com/user-attachments/assets/2c510e31-989e-4984-ba48-bc3793a5e70e" />

- 출석 누적 -> 출석율 증가 확인

---

## 📝 Note (주의 사항)

<img width="539" height="323" alt="스크린샷 2025-09-08 오후 9 32 54" src="https://github.com/user-attachments/assets/e99b0750-044f-4a3a-a2d4-c45cc8ccabe2" />

1. 여기서 내 출석률, 한 줄 공지 부분 구현했습니다 
2. 별도의 API 로 구분해서 구현한 다음에, 추후에 하나의 메서드로 묶어서 한 번에 DTO 로 전송할 예정입니다 (그 전까지 테스트가 너무 귀찮을 것 같고, 한꺼번에 하나 만들려고 하면 더 구현이 늦어질 것 같은 느낌이 들었습니다...)
3. 출석률은 편의상 소수점 첫째자리까지만 반환합니다
4. 전 진짜 구제불ㄹ능입니다 이거 두 개 구분해서 커밋하자고 생각해놓고 결국 한 번에 해버렸어요... 미안해요... 최대한 가독성 좋게 적고 주석 추가했습니다... 