### PR TITLE
✨ feat: 대시보드 구현 2 #50

### DIFF
--- a/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
+++ b/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
@@ -81,7 +81,12 @@ public enum ErrorCode {
     COMMENT_ALREADY_EXISTS("409", "이미 동일한 댓글이 존재합니다." ),
     COMMENT_NOT_FOUND("404", "댓글을 찾을 수 없습니다."),
     INVALID_COMMENT_ACCESS("403", "이 댓글에 접근할 권한이 없습니다." ),
-    ;
+
+    /**
+     * 📌 6. 칸반보드 (TO-DO) 관련
+     */
+    TODO_NOT_FOUND("404", "해당 TO-DO를 찾을 수 없습니다." ),
+    CANNOT_CHANGE_STATUS_OF_COMPLETED_TODO("403", "이미 완료된 TO-DO의 상태를 변경할 수 없습니다." ), ;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/grow/study_service/common/init/DataInit.java
+++ b/src/main/java/com/grow/study_service/common/init/DataInit.java
@@ -11,6 +11,8 @@ import com.grow.study_service.group.domain.repository.GroupRepository;
 import com.grow.study_service.groupmember.domain.enums.Role;
 import com.grow.study_service.groupmember.domain.model.GroupMember;
 import com.grow.study_service.groupmember.domain.repository.GroupMemberRepository;
+import com.grow.study_service.kanbanboard.domain.model.KanbanBoard;
+import com.grow.study_service.kanbanboard.domain.repository.KanbanBoardRepository;
 import com.grow.study_service.notice.domain.model.Notice;
 import com.grow.study_service.notice.domain.repository.NoticeRepository;
 import com.grow.study_service.post.domain.model.Post;
@@ -36,6 +38,7 @@ public class DataInit implements CommandLineRunner {
     private final BoardRepository boardRepository;
     private final RedisConnectionFactory redisConnectionFactory;
     private final NoticeRepository noticeRepository;
+    private final KanbanBoardRepository kanbanboardRepository;
 
     @Override
     public void run(String... args) throws Exception {
@@ -156,6 +159,78 @@ public class DataInit implements CommandLineRunner {
 
         notices.forEach(noticeRepository::save);  // NoticeRepository로 저장
 
-        log.info("Data init completed.");
+        // ------- KanbanBoard 더미 데이터 초기화 추가: groupMemberId=1로 30개 생성 ------- //
+        List<KanbanBoard> kanbanBoards = new ArrayList<>();
+
+        // 30개의 더미 데이터 생성 (2025년 8~10월 다양한 날짜 사용)
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #1", LocalDateTime.parse("2025-10-18T00:00:00"), LocalDateTime.parse("2025-10-26T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #2", LocalDateTime.parse("2025-08-19T00:00:00"), LocalDateTime.parse("2025-08-26T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #3", LocalDateTime.parse("2025-09-29T00:00:00"), LocalDateTime.parse("2025-10-05T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #4", LocalDateTime.parse("2025-08-09T00:00:00"), LocalDateTime.parse("2025-08-11T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #5", LocalDateTime.parse("2025-09-08T00:00:00"), LocalDateTime.parse("2025-09-15T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #6", LocalDateTime.parse("2025-10-30T00:00:00"), LocalDateTime.parse("2025-11-01T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #7", LocalDateTime.parse("2025-08-04T00:00:00"), LocalDateTime.parse("2025-08-13T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #8", LocalDateTime.parse("2025-10-09T00:00:00"), LocalDateTime.parse("2025-10-15T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #9", LocalDateTime.parse("2025-08-21T00:00:00"), LocalDateTime.parse("2025-08-23T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #10", LocalDateTime.parse("2025-08-14T00:00:00"), LocalDateTime.parse("2025-08-20T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #11", LocalDateTime.parse("2025-08-08T00:00:00"), LocalDateTime.parse("2025-08-13T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #12", LocalDateTime.parse("2025-09-20T00:00:00"), LocalDateTime.parse("2025-09-27T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #13", LocalDateTime.parse("2025-08-01T00:00:00"), LocalDateTime.parse("2025-08-03T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #14", LocalDateTime.parse("2025-10-17T00:00:00"), LocalDateTime.parse("2025-10-27T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #15", LocalDateTime.parse("2025-09-24T00:00:00"), LocalDateTime.parse("2025-09-29T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #16", LocalDateTime.parse("2025-09-02T00:00:00"), LocalDateTime.parse("2025-09-04T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #17", LocalDateTime.parse("2025-09-22T00:00:00"), LocalDateTime.parse("2025-09-29T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #18", LocalDateTime.parse("2025-10-08T00:00:00"), LocalDateTime.parse("2025-10-18T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #19", LocalDateTime.parse("2025-10-04T00:00:00"), LocalDateTime.parse("2025-10-10T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #20", LocalDateTime.parse("2025-10-03T00:00:00"), LocalDateTime.parse("2025-10-09T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #21", LocalDateTime.parse("2025-08-05T00:00:00"), LocalDateTime.parse("2025-08-15T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #22", LocalDateTime.parse("2025-10-17T00:00:00"), LocalDateTime.parse("2025-10-26T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #23", LocalDateTime.parse("2025-08-27T00:00:00"), LocalDateTime.parse("2025-09-03T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #24", LocalDateTime.parse("2025-08-31T00:00:00"), LocalDateTime.parse("2025-09-02T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #25", LocalDateTime.parse("2025-08-19T00:00:00"), LocalDateTime.parse("2025-08-29T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #26", LocalDateTime.parse("2025-09-18T00:00:00"), LocalDateTime.parse("2025-09-26T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #27", LocalDateTime.parse("2025-10-22T00:00:00"), LocalDateTime.parse("2025-10-29T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #28", LocalDateTime.parse("2025-09-11T00:00:00"), LocalDateTime.parse("2025-09-12T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #29", LocalDateTime.parse("2025-09-08T00:00:00"), LocalDateTime.parse("2025-09-18T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(1L, "더미 할 일 #30", LocalDateTime.parse("2025-09-08T00:00:00"), LocalDateTime.parse("2025-09-11T00:00:00")));
+
+        // ------- KanbanBoard 더미 데이터 초기화: groupMemberId=2로 30개 생성 ------- //
+
+        // 30개의 더미 데이터 생성 (2025년 8~10월 다양한 날짜 사용, groupMemberId=2, content 변경)
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #1", LocalDateTime.parse("2025-10-18T00:00:00"), LocalDateTime.parse("2025-10-26T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #2", LocalDateTime.parse("2025-08-19T00:00:00"), LocalDateTime.parse("2025-08-26T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #3", LocalDateTime.parse("2025-09-29T00:00:00"), LocalDateTime.parse("2025-10-05T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #4", LocalDateTime.parse("2025-08-09T00:00:00"), LocalDateTime.parse("2025-08-11T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #5", LocalDateTime.parse("2025-09-08T00:00:00"), LocalDateTime.parse("2025-09-15T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #6", LocalDateTime.parse("2025-10-30T00:00:00"), LocalDateTime.parse("2025-11-01T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #7", LocalDateTime.parse("2025-08-04T00:00:00"), LocalDateTime.parse("2025-08-13T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #8", LocalDateTime.parse("2025-10-09T00:00:00"), LocalDateTime.parse("2025-10-15T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #9", LocalDateTime.parse("2025-08-21T00:00:00"), LocalDateTime.parse("2025-08-23T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #10", LocalDateTime.parse("2025-08-14T00:00:00"), LocalDateTime.parse("2025-08-20T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #11", LocalDateTime.parse("2025-08-08T00:00:00"), LocalDateTime.parse("2025-08-13T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #12", LocalDateTime.parse("2025-09-20T00:00:00"), LocalDateTime.parse("2025-09-27T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #13", LocalDateTime.parse("2025-08-01T00:00:00"), LocalDateTime.parse("2025-08-03T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #14", LocalDateTime.parse("2025-10-17T00:00:00"), LocalDateTime.parse("2025-10-27T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #15", LocalDateTime.parse("2025-09-24T00:00:00"), LocalDateTime.parse("2025-09-29T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #16", LocalDateTime.parse("2025-09-02T00:00:00"), LocalDateTime.parse("2025-09-04T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #17", LocalDateTime.parse("2025-09-22T00:00:00"), LocalDateTime.parse("2025-09-29T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #18", LocalDateTime.parse("2025-10-08T00:00:00"), LocalDateTime.parse("2025-10-18T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #19", LocalDateTime.parse("2025-10-04T00:00:00"), LocalDateTime.parse("2025-10-10T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #20", LocalDateTime.parse("2025-10-03T00:00:00"), LocalDateTime.parse("2025-10-09T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #21", LocalDateTime.parse("2025-08-05T00:00:00"), LocalDateTime.parse("2025-08-15T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #22", LocalDateTime.parse("2025-10-17T00:00:00"), LocalDateTime.parse("2025-10-26T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #23", LocalDateTime.parse("2025-08-27T00:00:00"), LocalDateTime.parse("2025-09-03T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #24", LocalDateTime.parse("2025-08-31T00:00:00"), LocalDateTime.parse("2025-09-02T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #25", LocalDateTime.parse("2025-08-19T00:00:00"), LocalDateTime.parse("2025-08-29T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #26", LocalDateTime.parse("2025-09-18T00:00:00"), LocalDateTime.parse("2025-09-26T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #27", LocalDateTime.parse("2025-10-22T00:00:00"), LocalDateTime.parse("2025-10-29T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #28", LocalDateTime.parse("2025-09-11T00:00:00"), LocalDateTime.parse("2025-09-12T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #29", LocalDateTime.parse("2025-09-08T00:00:00"), LocalDateTime.parse("2025-09-18T00:00:00")));
+        kanbanBoards.add(KanbanBoard.create(2L, "멤버 2의 더미 할 일 #30", LocalDateTime.parse("2025-09-08T00:00:00"), LocalDateTime.parse("2025-09-11T00:00:00")));
+
+        // 모든 KanbanBoard 저장
+        kanbanBoards.forEach(kanbanboardRepository::save);
+
+        log.info("[INIT] 데이터 초기화 완료");
     }
 }

--- a/src/main/java/com/grow/study_service/common/init/DataInit.java
+++ b/src/main/java/com/grow/study_service/common/init/DataInit.java
@@ -40,7 +40,7 @@ public class DataInit implements CommandLineRunner {
     @Override
     public void run(String... args) throws Exception {
         // redis 초기화 로직 실행
-        redisConnectionFactory.getConnection().serverCommands().flushAll();
+        // redisConnectionFactory.getConnection().serverCommands().flushAll();
         log.debug("redis flush all.");
 
         List<Group> groups = new ArrayList<>();

--- a/src/main/java/com/grow/study_service/dashboard/application/DashboardService.java
+++ b/src/main/java/com/grow/study_service/dashboard/application/DashboardService.java
@@ -3,4 +3,5 @@ package com.grow.study_service.dashboard.application;
 public interface DashboardService {
     void incrementAttendanceDays(Long groupId, Long memberId);
     Double getAttendanceRate(Long groupId, Long memberId);
+    Double getProgressPercentage(Long groupId, Long memberId);
 }

--- a/src/main/java/com/grow/study_service/dashboard/presentation/DashboardController.java
+++ b/src/main/java/com/grow/study_service/dashboard/presentation/DashboardController.java
@@ -2,13 +2,14 @@ package com.grow.study_service.dashboard.presentation;
 
 import com.grow.study_service.common.rsdata.RsData;
 import com.grow.study_service.dashboard.application.DashboardService;
+import com.grow.study_service.kanbanboard.presentation.controller.KanbanBoardController;
 import com.grow.study_service.notice.application.service.NoticeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/dashboard")
+@RequestMapping("/api/v1/study/dashboard")
 public class DashboardController {
 
     private final NoticeService noticeService;
@@ -71,13 +72,11 @@ public class DashboardController {
 
     // == 칸반보드 (To-do list) API ==
 
-    // 투두 조회
-
-    // 투두 등록
-
-    // 투두 상태 변경 (시작 전에서 실행 중 / 완료)
-
-
+    /**
+     * == 칸반보드 (To-do list) API ==
+     * TodoController 에서 구현될 예정입니다.
+     * @see KanbanBoardController
+     */
 
     // 오늘의 퀴즈
 }

--- a/src/main/java/com/grow/study_service/dashboard/presentation/DashboardController.java
+++ b/src/main/java/com/grow/study_service/dashboard/presentation/DashboardController.java
@@ -2,6 +2,7 @@ package com.grow.study_service.dashboard.presentation;
 
 import com.grow.study_service.common.rsdata.RsData;
 import com.grow.study_service.dashboard.application.DashboardService;
+import com.grow.study_service.dashboard.presentation.dto.RemainingDaysDto;
 import com.grow.study_service.notice.application.service.NoticeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -54,4 +55,30 @@ public class DashboardController {
                 attendanceRate
         );
     }
+
+    // 현재 진행률을 나타내는 퍼센트 API
+    @GetMapping("/remaining-percentage/{groupId}")
+    public RsData<Double> getProgressPercentage(@RequestHeader("X-Authorization-Id") Long memberId,
+                                                 @PathVariable("groupId") Long groupId) {
+
+        Double progressPercentage = dashboardService.getProgressPercentage(groupId, memberId);
+
+        return new RsData<>(
+                "200",
+                "진행률 퍼센트 조회 완료",
+                progressPercentage
+        );
+    }
+
+    // == 칸반보드 (To-do list) API ==
+
+    // 투두 조회
+
+    // 투두 등록
+
+    // 투두 상태 변경 (시작 전에서 실행 중 / 완료)
+
+
+
+    // 오늘의 퀴즈
 }

--- a/src/main/java/com/grow/study_service/dashboard/presentation/DashboardController.java
+++ b/src/main/java/com/grow/study_service/dashboard/presentation/DashboardController.java
@@ -2,7 +2,6 @@ package com.grow.study_service.dashboard.presentation;
 
 import com.grow.study_service.common.rsdata.RsData;
 import com.grow.study_service.dashboard.application.DashboardService;
-import com.grow.study_service.dashboard.presentation.dto.RemainingDaysDto;
 import com.grow.study_service.notice.application.service.NoticeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/grow/study_service/group/domain/model/Group.java
+++ b/src/main/java/com/grow/study_service/group/domain/model/Group.java
@@ -199,7 +199,7 @@ public class Group {
     }
 
     // 총 일수 계산: ChronoUnit 으로 일 단위 차이 (시작일 포함 위해 +1)
-    public double calculateTotalAttendanceDays(LocalDateTime start, LocalDateTime end) {
+    public long calculateTotalDays (LocalDateTime start, LocalDateTime end) {
         long totalDays = ChronoUnit.DAYS.between(start.toLocalDate(), end.toLocalDate()) + 1;
 
         if (totalDays <= 0) {
@@ -207,7 +207,18 @@ public class Group {
             throw new DomainException(ErrorCode.INVALID_DATE_RANGE);
         }
 
-        // 소수점 첫째 자리까지만 반올림
-        return Math.round(totalDays * 10) / 10.0;
+        return totalDays;
+    }
+
+    // 시작에서 현재까지의 경과 일수
+    public long calculateElapsedDays(LocalDateTime start) {
+        return ChronoUnit.DAYS.between(start.toLocalDate(), LocalDateTime.now().toLocalDate()) + 1;
+    }
+
+    // 진행률 계산: 남은 일수 / 전체 일수
+    public double calculateProgressPercentage(long elapsedDays, long totalDays) {
+        double rate = (elapsedDays / (double) totalDays) * 100;
+
+        return Math.round(rate * 10) / 10.0;
     }
 }

--- a/src/main/java/com/grow/study_service/groupmember/domain/model/GroupMember.java
+++ b/src/main/java/com/grow/study_service/groupmember/domain/model/GroupMember.java
@@ -63,8 +63,7 @@ public class GroupMember {
      */
     public static GroupMember create(Long memberId,
                                      Long groupId,
-                                     Role role
-    ) {
+                                     Role role) {
 
         verifyParameters(memberId, groupId, role);
         return new GroupMember(
@@ -73,6 +72,7 @@ public class GroupMember {
                 groupId,
                 role,
                 LocalDateTime.now(), // 데이터베이스에 저장될 때는 현재 시각을 사용함. (자동 생성)
+                0,
                 null // 버전 자동 생성
         );
     }
@@ -94,6 +94,7 @@ public class GroupMember {
                                  Long groupId,
                                  Role role,
                                  LocalDateTime joinedAt,
+                                 int totalAttendanceDays,
                                  Long version) {
 
         verifyParameters(memberId, groupId, role);
@@ -105,6 +106,7 @@ public class GroupMember {
                 groupId,
                 role,
                 joinedAt,
+                totalAttendanceDays,
                 version
         );
     }
@@ -206,8 +208,7 @@ public class GroupMember {
      * @param totalDays 출석일 수 (총 출석일 수)
      * @return 출석률 (0 ~ 100), 소수점 첫 자리에서 반올림.
      */
-    public Double calculateTotalAttendanceRate(double totalDays) {
-        double rate = (this.totalAttendanceDays / totalDays) * 100;
-        return Math.round(rate * 10) / 10.0;
+    public double calculateTotalAttendanceRate(long totalDays) {
+        return (this.totalAttendanceDays / (double) totalDays) * 100;
     }
 }

--- a/src/main/java/com/grow/study_service/groupmember/domain/repository/GroupMemberRepository.java
+++ b/src/main/java/com/grow/study_service/groupmember/domain/repository/GroupMemberRepository.java
@@ -16,4 +16,5 @@ public interface GroupMemberRepository {
 	Optional<GroupMember> findByGroupIdAndLeader(Long groupId);
 	boolean isLeader(Long groupId, Long memberId);
 	boolean existsByMemberIdAndGroupId(Long memberId, Long groupId);
+	Optional<GroupMember> findByGroupIdAndMemberId(Long groupId, Long memberId);
 }

--- a/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberJpaRepository.java
+++ b/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberJpaRepository.java
@@ -48,4 +48,6 @@ public interface GroupMemberJpaRepository
                      @Param("memberId") Long memberId);
 
     boolean existsByMemberIdAndGroupId(Long memberId, Long groupId);
+
+    Optional<GroupMemberJpaEntity> findByGroupIdAndMemberId(Long groupId, Long memberId);
 }

--- a/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberRepositoryImpl.java
+++ b/src/main/java/com/grow/study_service/groupmember/infra/persistence/repository/GroupMemberRepositoryImpl.java
@@ -96,4 +96,17 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepository {
 	public boolean existsByMemberIdAndGroupId(Long memberId, Long groupId) {
 		return groupMemberJpaRepository.existsByMemberIdAndGroupId(memberId, groupId);
 	}
+
+	/**
+	 * 주어진 그룹 ID와 멤버 ID로 그룹 멤버를 조회합니다.
+	 *
+	 * @param groupId 그룹의 고유 식별자
+	 * @param memberId 멤버의 고유 식별자
+	 * @return 조회된 그룹 멤버를 포함한 Optional 객체. 존재하지 않으면 빈 Optional 반환.
+	 */
+	@Override
+	public Optional<GroupMember> findByGroupIdAndMemberId(Long groupId, Long memberId) {
+		return groupMemberJpaRepository.findByGroupIdAndMemberId(groupId, memberId)
+				.map(GroupMemberMapper::toDomain);
+	}
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/application/KanbanBoardService.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/application/KanbanBoardService.java
@@ -9,4 +9,6 @@ public interface KanbanBoardService {
     Long createTodo(Long memberId, Long groupId, TodoCreateRequest request);
 
     List<KanbanBoardResponse> getTodos(Long memberId, Long groupId);
+
+    Long updateTodo(Long memberId, TodoCreateRequest request, Long kanbanId);
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/application/KanbanBoardService.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/application/KanbanBoardService.java
@@ -1,0 +1,7 @@
+package com.grow.study_service.kanbanboard.application;
+
+import com.grow.study_service.kanbanboard.presentation.dto.TodoCreateRequest;
+
+public interface KanbanBoardService {
+    Long createTodo(Long memberId, Long groupId, TodoCreateRequest request);
+}

--- a/src/main/java/com/grow/study_service/kanbanboard/application/KanbanBoardService.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/application/KanbanBoardService.java
@@ -1,7 +1,12 @@
 package com.grow.study_service.kanbanboard.application;
 
 import com.grow.study_service.kanbanboard.presentation.dto.TodoCreateRequest;
+import com.grow.study_service.kanbanboard.presentation.dto.response.KanbanBoardResponse;
+
+import java.util.List;
 
 public interface KanbanBoardService {
     Long createTodo(Long memberId, Long groupId, TodoCreateRequest request);
+
+    List<KanbanBoardResponse> getTodos(Long memberId, Long groupId);
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/application/KanbanBoardServiceImpl.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/application/KanbanBoardServiceImpl.java
@@ -7,10 +7,14 @@ import com.grow.study_service.groupmember.domain.repository.GroupMemberRepositor
 import com.grow.study_service.kanbanboard.domain.model.KanbanBoard;
 import com.grow.study_service.kanbanboard.domain.repository.KanbanBoardRepository;
 import com.grow.study_service.kanbanboard.presentation.dto.TodoCreateRequest;
+import com.grow.study_service.kanbanboard.presentation.dto.response.KanbanBoardResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -54,5 +58,35 @@ public class KanbanBoardServiceImpl implements KanbanBoardService {
         log.info("[KanbanBoard][Create][END] 투두 생성 요청 처리 완료: kanbanBoard={}", saved.getKanbanId());
 
         return saved.getKanbanId();
+    }
+
+    /**
+     * 주어진 회원 ID와 그룹 ID를 기반으로 해당 그룹의 TO-DO 목록을 조회합니다.
+     * 회원의 그룹 가입 여부를 검증한 후, 현재 날짜부터 한 달 후까지의 KanbanBoard 목록을 startDate 오름차순으로 반환합니다.
+     *
+     * @param memberId 회원 ID
+     * @param groupId 그룹 ID
+     * @return 해당 범위 내 KanbanBoardResponse 목록
+     * @throws ServiceException 그룹 멤버가 존재하지 않을 경우 GROUP_MEMBER_NOT_FOUND 오류 발생
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<KanbanBoardResponse> getTodos(Long memberId, Long groupId) {
+        // 회원 ID + 그룹 ID 를 기반으로 그룹 멤버를 조회
+        // 해당 그룹에 가입된 회원인지 검증이 동시에 가능
+        GroupMember groupMember = groupMemberRepository.findByGroupIdAndMemberId(groupId, memberId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.GROUP_MEMBER_NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // 해당 그룹 멤버를 기준으로 한 달 기준의 투두 목록을 조회 (오늘로부터 한 달 뒤까지)
+        List<KanbanBoard> list = kanbanBoardRepository.findByGroupMemberIdAndDateBetween(groupMember.getGroupMemberId(),
+                now,
+                now.plusMonths(1)
+        );
+
+        return list.stream()
+                .map(KanbanBoardResponse::of)
+                .toList();
     }
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/application/KanbanBoardServiceImpl.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/application/KanbanBoardServiceImpl.java
@@ -1,0 +1,58 @@
+package com.grow.study_service.kanbanboard.application;
+
+import com.grow.study_service.common.exception.ErrorCode;
+import com.grow.study_service.common.exception.service.ServiceException;
+import com.grow.study_service.groupmember.domain.model.GroupMember;
+import com.grow.study_service.groupmember.domain.repository.GroupMemberRepository;
+import com.grow.study_service.kanbanboard.domain.model.KanbanBoard;
+import com.grow.study_service.kanbanboard.domain.repository.KanbanBoardRepository;
+import com.grow.study_service.kanbanboard.presentation.dto.TodoCreateRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KanbanBoardServiceImpl implements KanbanBoardService {
+
+    private final KanbanBoardRepository kanbanBoardRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    /**
+     * 새로운 TO-DO 항목을 생성합니다.
+     * 주어진 회원 ID와 그룹 ID를 기반으로 그룹 멤버를 검증한 후, KanbanBoard 엔티티를 생성하고 저장합니다.
+     *
+     * @param memberId 회원 ID
+     * @param groupId 그룹 ID
+     * @param request TO-DO 생성 요청 객체 (내용, 시작 날짜, 종료 날짜 포함)
+     * @return 생성된 TO-DO의 ID (KanbanId)
+     * @throws ServiceException 그룹 멤버가 존재하지 않을 경우 GROUP_MEMBER_NOT_FOUND 오류 발생
+     */
+    @Override
+    @Transactional
+    public Long createTodo(Long memberId, Long groupId, TodoCreateRequest request) {
+        log.info("[KanbanBoard][Create][START] 투두 생성 요청: memberId={}, groupId={}, request={}", memberId, groupId, request);
+
+        // 회원 ID + 그룹 ID 를 기반으로 그룹 멤버를 조회
+        // 해당 그룹에 가입된 회원인지 검증이 동시에 가능
+        GroupMember groupMember = groupMemberRepository.findByGroupIdAndMemberId(groupId, memberId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.GROUP_MEMBER_NOT_FOUND));
+
+        // 투두 생성
+        KanbanBoard kanbanBoard = KanbanBoard.create(
+                groupMember.getGroupMemberId(),
+                request.getContent(),
+                request.getStartDate(),
+                request.getEndDate()
+        );
+
+        // 저장
+        KanbanBoard saved = kanbanBoardRepository.save(kanbanBoard);
+
+        log.info("[KanbanBoard][Create][END] 투두 생성 요청 처리 완료: kanbanBoard={}", saved.getKanbanId());
+
+        return saved.getKanbanId();
+    }
+}

--- a/src/main/java/com/grow/study_service/kanbanboard/application/KanbanBoardServiceImpl.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/application/KanbanBoardServiceImpl.java
@@ -1,6 +1,7 @@
 package com.grow.study_service.kanbanboard.application;
 
 import com.grow.study_service.common.exception.ErrorCode;
+import com.grow.study_service.common.exception.domain.DomainException;
 import com.grow.study_service.common.exception.service.ServiceException;
 import com.grow.study_service.groupmember.domain.model.GroupMember;
 import com.grow.study_service.groupmember.domain.repository.GroupMemberRepository;
@@ -88,5 +89,33 @@ public class KanbanBoardServiceImpl implements KanbanBoardService {
         return list.stream()
                 .map(KanbanBoardResponse::of)
                 .toList();
+    }
+
+    /**
+     * TO-DO 항목을 업데이트합니다.
+     * 주어진 kanbanId로 TO-DO를 조회한 후, 요청된 내용으로 업데이트하고 저장합니다.
+     * 업데이트는 도메인 로직에 위임되며, 이미 완료된 TO-DO는 변경할 수 없습니다.
+     *
+     * @param memberId 회원 ID (현재 사용되지 않음, 추후 권한 검증 등에 사용 가능)
+     * @param request TO-DO 업데이트 요청 객체 (내용, 시작 날짜, 종료 날짜, 상태 포함)
+     * @param kanbanId 업데이트할 TO-DO의 ID
+     * @return 업데이트된 TO-DO의 ID
+     * @throws ServiceException TO-DO가 존재하지 않을 경우 TODO_NOT_FOUND 오류 발생
+     * @throws DomainException 이미 완료된 TO-DO를 변경하려 할 경우 CANNOT_CHANGE_STATUS_OF_COMPLETED_TODO 오류 발생
+     */
+    @Override
+    @Transactional
+    public Long updateTodo(Long memberId, TodoCreateRequest request, Long kanbanId) {
+        // 할 일 조회
+        KanbanBoard findTodo = kanbanBoardRepository.findById(kanbanId).orElseThrow(() ->
+                new ServiceException(ErrorCode.TODO_NOT_FOUND));
+
+        // 내용, 날짜, 상태 변경 - 도메인 로직에 위임
+        findTodo.updateTodo(request);
+
+        // 새롭게 업데이트
+        KanbanBoard saved = kanbanBoardRepository.save(findTodo);
+
+        return saved.getKanbanId();
     }
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/domain/enums/KanbanStatus.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/domain/enums/KanbanStatus.java
@@ -1,7 +1,14 @@
 package com.grow.study_service.kanbanboard.domain.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum KanbanStatus {
-	READY,
-	IN_PROGRESS,
-	DONE
+	READY("시작 전"),
+	IN_PROGRESS("진행 중"),
+	DONE("완료");
+
+	private final String description;
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/domain/model/KanbanBoard.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/domain/model/KanbanBoard.java
@@ -2,8 +2,11 @@ package com.grow.study_service.kanbanboard.domain.model;
 
 import java.time.LocalDateTime;
 
+import com.grow.study_service.common.exception.ErrorCode;
+import com.grow.study_service.common.exception.domain.DomainException;
 import com.grow.study_service.kanbanboard.domain.enums.KanbanStatus;
 
+import com.grow.study_service.kanbanboard.presentation.dto.TodoCreateRequest;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -70,5 +73,40 @@ public class KanbanBoard {
 	public static KanbanBoard of(Long toDoId, Long groupMemberId, String toDoContent, KanbanStatus isCompleted,
 			LocalDateTime startDate, LocalDateTime endDate) {
 		return new KanbanBoard(toDoId, groupMemberId, toDoContent, isCompleted, startDate, endDate);
+	}
+
+
+	/**
+	 * TO-DO의 내용, 상태, 날짜를 업데이트합니다.
+	 * 이미 완료된 상태(DONE)인 경우 변경을 금지하며, 변경된 필드만 업데이트합니다.
+	 *
+	 * @param request TO-DO 업데이트 요청 객체
+	 * @throws DomainException 이미 완료된 TO-DO를 변경하려 할 경우 CANNOT_CHANGE_STATUS_OF_COMPLETED_TODO 오류 발생
+	 */
+	public void updateTodo(TodoCreateRequest request) {
+		// 이미 완료된 할 일은 일정을 변경할 수 없음
+		// (이게 합리적인가 모르겠긴 함 근데 일단 제약이 좀 있어야 할 거 같고...)
+		if (this.status == KanbanStatus.DONE) {
+			throw new DomainException(ErrorCode.CANNOT_CHANGE_STATUS_OF_COMPLETED_TODO);
+		}
+
+		// 상태가 변경되었는지 확인
+		if (!(this.status).equals(request.getStatus())) {
+			this.status = request.getStatus();
+		}
+
+		// 내용이 변경되었는지 확인
+		if (!this.content.equals(request.getContent())) {
+			this.content = request.getContent();
+		}
+
+		// 날짜가 변경되었는지 확인
+		if (!this.startDate.equals(request.getStartDate())) {
+			this.startDate = request.getStartDate();
+		}
+
+		if (!this.endDate.equals(request.getEndDate())) {
+			this.endDate = request.getEndDate();
+		}
 	}
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/domain/model/KanbanBoard.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/domain/model/KanbanBoard.java
@@ -4,45 +4,48 @@ import java.time.LocalDateTime;
 
 import com.grow.study_service.kanbanboard.domain.enums.KanbanStatus;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class KanbanBoard {
-	private final Long toDoId;
+	private final Long kanbanId;
 	private final Long GroupMemberId;
-	private String toDoContent;
-	private KanbanStatus isCompleted;
+	private String content;
+	private KanbanStatus status;
 	private LocalDateTime startDate;
 	private LocalDateTime endDate;
 
-	private KanbanBoard (Long toDoId, Long groupMemberId, String toDoContent, KanbanStatus isCompleted,
-			LocalDateTime startDate, LocalDateTime endDate) {
-		this.toDoId = toDoId;
-		this.GroupMemberId = groupMemberId;
-		this.toDoContent = toDoContent;
-		this.isCompleted = isCompleted;
-		this.startDate = startDate;
-		this.endDate = endDate;
-	}
-
-	public static KanbanBoard create(Long groupMemberId, String toDoContent, LocalDateTime startDate, LocalDateTime endDate) {
-		return new KanbanBoard(null, groupMemberId, toDoContent, KanbanStatus.READY, startDate, endDate);
+	public static KanbanBoard create(Long groupMemberId,
+									 String content,
+									 LocalDateTime startDate,
+									 LocalDateTime endDate
+	) {
+		return new KanbanBoard(
+				null,
+				groupMemberId,
+				content,
+				KanbanStatus.READY,
+				startDate,
+				endDate
+		);
 	}
 
 	public void updateContent(String newContent) {
 		if (newContent == null || newContent.isBlank()) {
 			throw new IllegalArgumentException("할 일 내용은 비어 있을 수 없습니다.");
 		}
-		this.toDoContent = newContent;
+		this.content = newContent;
 	}
 
 	public void markInProgress(LocalDateTime now) {
-		this.isCompleted = KanbanStatus.IN_PROGRESS;
+		this.status = KanbanStatus.IN_PROGRESS;
 		this.startDate   = now;
 	}
 
 	public void markDone(LocalDateTime now) {
-		this.isCompleted = KanbanStatus.DONE;
+		this.status = KanbanStatus.DONE;
 		this.endDate     = now;
 	}
 
@@ -56,7 +59,7 @@ public class KanbanBoard {
 		if (newStart.isBefore(LocalDateTime.now())) {
 			throw new IllegalArgumentException("시작일은 현재 이후여야 합니다.");
 		}
-		if (this.isCompleted == KanbanStatus.DONE) {
+		if (this.status == KanbanStatus.DONE) {
 			throw new IllegalStateException("완료된 할 일은 일정을 변경할 수 없습니다.");
 		}
 

--- a/src/main/java/com/grow/study_service/kanbanboard/domain/repository/KanbanBoardRepository.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/domain/repository/KanbanBoardRepository.java
@@ -1,5 +1,6 @@
 package com.grow.study_service.kanbanboard.domain.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,4 +11,5 @@ public interface KanbanBoardRepository {
 	Optional<KanbanBoard> findById(Long toDoId);
 	List<KanbanBoard> findByGroupMemberId(Long groupMemberId);
 	void delete(KanbanBoard kanbanBoard);
+	List<KanbanBoard> findByGroupMemberIdAndDateBetween(Long groupMemberId, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/infra/persistence/entity/KanbanBoardJpaEntity.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/infra/persistence/entity/KanbanBoardJpaEntity.java
@@ -14,10 +14,15 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Builder
-@Table(name = "kanban_board")
+@Table(
+		name = "kanban_board",
+		indexes = {
+				// groupMemberId로 필터링 후 startDate로 범위 검색
+				@Index(name = "idx_group_member_start_date", columnList = "groupMemberId, startDate")
+		}
+)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-
 public class KanbanBoardJpaEntity {
 
 	@Id

--- a/src/main/java/com/grow/study_service/kanbanboard/infra/persistence/mapper/KanbanBoardMapper.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/infra/persistence/mapper/KanbanBoardMapper.java
@@ -2,28 +2,34 @@ package com.grow.study_service.kanbanboard.infra.persistence.mapper;
 
 import com.grow.study_service.kanbanboard.domain.model.KanbanBoard;
 import com.grow.study_service.kanbanboard.infra.persistence.entity.KanbanBoardJpaEntity;
+import com.grow.study_service.kanbanboard.infra.persistence.entity.KanbanBoardJpaEntity.KanbanBoardJpaEntityBuilder;
 
 public class KanbanBoardMapper {
 
-	public static KanbanBoard toDomain(KanbanBoardJpaEntity e) {
-		return KanbanBoard.of(
-			e.getToDoId(),
-			e.getGroupMemberId(),
-			e.getToDoContent(),
-			e.getIsCompleted(),
-			e.getStartDate(),
-			e.getEndDate()
-		);
-	}
+    public static KanbanBoard toDomain(KanbanBoardJpaEntity e) {
+        return KanbanBoard.of(
+                e.getToDoId(),
+                e.getGroupMemberId(),
+                e.getToDoContent(),
+                e.getIsCompleted(),
+                e.getStartDate(),
+                e.getEndDate()
+        );
+    }
 
-	public static KanbanBoardJpaEntity toEntity(KanbanBoard d) {
-		return KanbanBoardJpaEntity.builder()
-			.toDoId(d.getKanbanId())
-			.groupMemberId(d.getGroupMemberId())
-			.toDoContent(d.getContent())
-			.isCompleted(d.getStatus())
-			.startDate(d.getStartDate())
-			.endDate(d.getEndDate())
-			.build();
-	}
+    public static KanbanBoardJpaEntity toEntity(KanbanBoard domain) {
+        KanbanBoardJpaEntityBuilder builder = KanbanBoardJpaEntity.builder()
+                .toDoId(domain.getKanbanId())
+                .groupMemberId(domain.getGroupMemberId())
+                .toDoContent(domain.getContent())
+                .isCompleted(domain.getStatus())
+                .startDate(domain.getStartDate())
+                .endDate(domain.getEndDate());
+
+        if (domain.getKanbanId() != null) {
+            builder.toDoId(domain.getKanbanId());
+        }
+
+        return builder.build();
+    }
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/infra/persistence/mapper/KanbanBoardMapper.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/infra/persistence/mapper/KanbanBoardMapper.java
@@ -18,10 +18,10 @@ public class KanbanBoardMapper {
 
 	public static KanbanBoardJpaEntity toEntity(KanbanBoard d) {
 		return KanbanBoardJpaEntity.builder()
-			.toDoId(d.getToDoId())
+			.toDoId(d.getKanbanId())
 			.groupMemberId(d.getGroupMemberId())
-			.toDoContent(d.getToDoContent())
-			.isCompleted(d.getIsCompleted())
+			.toDoContent(d.getContent())
+			.isCompleted(d.getStatus())
 			.startDate(d.getStartDate())
 			.endDate(d.getEndDate())
 			.build();

--- a/src/main/java/com/grow/study_service/kanbanboard/infra/persistence/repository/KanbanBoardJpaRepository.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/infra/persistence/repository/KanbanBoardJpaRepository.java
@@ -1,12 +1,32 @@
 package com.grow.study_service.kanbanboard.infra.persistence.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.grow.study_service.kanbanboard.infra.persistence.entity.KanbanBoardJpaEntity;
+import org.springframework.data.jpa.repository.Query;
 
 public interface KanbanBoardJpaRepository
-	extends JpaRepository<KanbanBoardJpaEntity, Long> {
-	List<KanbanBoardJpaEntity> findByGroupMemberId(Long groupMemberId);
+        extends JpaRepository<KanbanBoardJpaEntity, Long> {
+    List<KanbanBoardJpaEntity> findByGroupMemberId(Long groupMemberId);
+
+    /**
+     * 그룹 멤버 ID를 기준으로 지정된 시작 날짜 범위 내의 KanbanBoardJpaEntity 목록을 조회합니다.
+     * startDate 필드가 startDate와 endDate 사이에 있는 엔티티를 startDate 오름차순으로 정렬하여 반환합니다.
+     *
+     * @param groupMemberId 그룹 멤버 ID
+     * @param startDate     범위 시작 날짜/시간 (포함)
+     * @param endDate       범위 종료 날짜/시간 (포함)
+     * @return 해당 범위 내 KanbanBoardJpaEntity 목록 (startDate 오름차순 정렬)
+     */
+    @Query("SELECT k FROM KanbanBoardJpaEntity k " +
+            "WHERE k.groupMemberId = :groupMemberId " +
+            "AND k.startDate BETWEEN :startDate AND :endDate " +
+            "order by k.startDate asc")
+    List<KanbanBoardJpaEntity> findByGroupMemberIdAndDateBetween(@Param("groupMemberId") Long groupMemberId,
+                                                                 @Param("startDate") LocalDateTime startDate,
+                                                                 @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/infra/persistence/repository/KanbanBoardRepositoryImpl.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/infra/persistence/repository/KanbanBoardRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.grow.study_service.kanbanboard.infra.persistence.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -41,5 +42,24 @@ public class KanbanBoardRepositoryImpl implements KanbanBoardRepository {
 	@Override
 	public void delete(KanbanBoard board) {
 		kanbanBoardJpaRepository.delete(KanbanBoardMapper.toEntity(board));
+	}
+
+	/**
+	 * 그룹 멤버 ID를 기준으로 지정된 날짜 범위 내의 KanbanBoard 목록을 조회합니다.
+	 * JPA 리포지토리를 통해 엔티티를 조회한 후, 도메인 객체로 매핑하여 반환합니다.
+	 *
+	 * @param groupMemberId 그룹 멤버 ID
+	 * @param startDate 범위 시작 날짜/시간 (포함)
+	 * @param endDate 범위 종료 날짜/시간 (포함)
+	 * @return 해당 범위 내 KanbanBoard 도메인 객체 목록
+	 */
+	@Override
+	public List<KanbanBoard> findByGroupMemberIdAndDateBetween(Long groupMemberId,
+															   LocalDateTime startDate,
+															   LocalDateTime endDate) {
+		return kanbanBoardJpaRepository.findByGroupMemberIdAndDateBetween(groupMemberId, startDate, endDate)
+				.stream()
+				.map(KanbanBoardMapper::toDomain)
+				.toList();
 	}
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/presentation/controller/KanbanBoardController.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/presentation/controller/KanbanBoardController.java
@@ -46,4 +46,19 @@ public class KanbanBoardController {
                 responses // 칸반보드 리스트
         );
     }
+
+    // 칸반보드 내용 / status / date 변경
+    @PatchMapping("/todos/{todoId}")
+    public RsData<Long> updateTodo(@RequestHeader("X-Authorization-Id") Long memberId,
+                                   @PathVariable("todoId") Long kanbanId,
+                                   @RequestBody TodoCreateRequest request) {
+
+        Long todoId = kanbanBoardService.updateTodo(memberId, request, kanbanId);
+
+        return new RsData<>(
+                "200",
+                "투두 상태 변경 완료",
+                todoId // 칸반보드 ID 단건
+        );
+    }
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/presentation/controller/KanbanBoardController.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/presentation/controller/KanbanBoardController.java
@@ -4,8 +4,11 @@ package com.grow.study_service.kanbanboard.presentation.controller;
 import com.grow.study_service.common.rsdata.RsData;
 import com.grow.study_service.kanbanboard.application.KanbanBoardService;
 import com.grow.study_service.kanbanboard.presentation.dto.TodoCreateRequest;
+import com.grow.study_service.kanbanboard.presentation.dto.response.KanbanBoardResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,7 +29,21 @@ public class KanbanBoardController {
         return new RsData<>(
                 "201",
                 "투두 등록 완료",
-                response
+                response // 칸반보드 ID 단건
+        );
+    }
+
+    // 칸반보드 조회 (한 달 주기로 조회)
+    @GetMapping("/todos/{groupId}")
+    public RsData<List<KanbanBoardResponse>> getTodos(@RequestHeader("X-Authorization-Id") Long memberId,
+                                                      @PathVariable("groupId") Long groupId) {
+
+        List<KanbanBoardResponse> responses = kanbanBoardService.getTodos(memberId, groupId);
+
+        return new RsData<>(
+                "200",
+                "투두 조회 완료",
+                responses // 칸반보드 리스트
         );
     }
 }

--- a/src/main/java/com/grow/study_service/kanbanboard/presentation/controller/KanbanBoardController.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/presentation/controller/KanbanBoardController.java
@@ -1,0 +1,32 @@
+package com.grow.study_service.kanbanboard.presentation.controller;
+
+
+import com.grow.study_service.common.rsdata.RsData;
+import com.grow.study_service.kanbanboard.application.KanbanBoardService;
+import com.grow.study_service.kanbanboard.presentation.dto.TodoCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/study/kanbanBoard")
+public class KanbanBoardController {
+
+    private final KanbanBoardService kanbanBoardService;
+
+    // 칸반보드에 일정 등록
+    @PostMapping("/todos/{groupId}")
+    public RsData<Long> createTodo(@RequestHeader("X-Authorization-Id") Long memberId,
+                                   @PathVariable("groupId") Long groupId,
+                                   @RequestBody TodoCreateRequest request) {
+
+        // 클라이언트에서 ID 를 받아 라우팅 하기 위함
+        Long response = kanbanBoardService.createTodo(memberId, groupId, request);
+
+        return new RsData<>(
+                "201",
+                "투두 등록 완료",
+                response
+        );
+    }
+}

--- a/src/main/java/com/grow/study_service/kanbanboard/presentation/dto/TodoCreateRequest.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/presentation/dto/TodoCreateRequest.java
@@ -1,0 +1,28 @@
+package com.grow.study_service.kanbanboard.presentation.dto;
+
+import com.grow.study_service.kanbanboard.domain.enums.KanbanStatus;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class TodoCreateRequest {
+
+    @NotBlank(message = "내용은 비어 있을 수 없습니다.")
+    private final String content;
+
+    @NotNull(message = "상태는 null일 수 없습니다.")
+    private final KanbanStatus status;
+
+    @NotNull(message = "시작 날짜는 null일 수 없습니다.")
+    private final LocalDateTime startDate;
+
+    @NotNull(message = "종료 날짜는 null일 수 없습니다.")
+    @Future(message = "종료 날짜는 미래여야 합니다.")
+    private final LocalDateTime endDate;
+}

--- a/src/main/java/com/grow/study_service/kanbanboard/presentation/dto/response/KanbanBoardResponse.java
+++ b/src/main/java/com/grow/study_service/kanbanboard/presentation/dto/response/KanbanBoardResponse.java
@@ -1,0 +1,27 @@
+package com.grow.study_service.kanbanboard.presentation.dto.response;
+
+import com.grow.study_service.kanbanboard.domain.enums.KanbanStatus;
+import com.grow.study_service.kanbanboard.domain.model.KanbanBoard;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class KanbanBoardResponse {
+
+    private String content; // 할 일 내용
+    private KanbanStatus status; // 할 일 상태
+    private LocalDateTime startDate; // 할 일 시작일
+    private LocalDateTime endDate; // 할 일 종료일
+
+    public static KanbanBoardResponse of(KanbanBoard kanbanBoard) {
+        return new KanbanBoardResponse(
+                kanbanBoard.getContent(),
+                kanbanBoard.getStatus(),
+                kanbanBoard.getStartDate(),
+                kanbanBoard.getEndDate()
+        );
+    }
+}


### PR DESCRIPTION
## ✅ Check List(필수)
- [X] 코드에 주석 추가 완료
- [X] 테스트 통과 확인

+ 📸 Screenshot or Test Result

<img width="841" height="473" alt="스크린샷 2025-09-12 오후 5 32 16" src="https://github.com/user-attachments/assets/b03c8e35-304c-4956-b95e-70b8353c2a74" />
<img width="774" height="192" alt="스크린샷 2025-09-12 오후 5 32 31" src="https://github.com/user-attachments/assets/72119ee5-6ba8-4b2b-85c4-4a1c45a6f06b" />

- 할 일 등록 DB 확인 (칸반보드, 투두 리스트라고 생각해도 될 듯 -> 노션의 칸반보드 like...)

<img width="817" height="779" alt="스크린샷 2025-09-12 오후 9 48 15" src="https://github.com/user-attachments/assets/4c9c08e7-faee-4371-bd46-7a2e9125af19" />
<img width="819" height="766" alt="스크린샷 2025-09-12 오후 9 48 22" src="https://github.com/user-attachments/assets/4660bee7-6188-44c5-81b4-43af39646fa0" />

- 본인의 개별적인 todo list 를 조회할 수 있습니다 (오름차순으로 정렬됩니다, 오늘로부터 한 달 기준으로 보여짐)

<img width="718" height="76" alt="스크린샷 2025-09-12 오후 10 44 37" src="https://github.com/user-attachments/assets/bb70adcd-37e5-439d-bdad-c8395ca721ba" />
<img width="766" height="78" alt="스크린샷 2025-09-12 오후 10 44 54" src="https://github.com/user-attachments/assets/1867ef39-5e7e-4837-914a-956b2766ad27" />
<img width="755" height="88" alt="스크린샷 2025-09-12 오후 10 45 10" src="https://github.com/user-attachments/assets/ad778ed1-5996-4e25-924f-ce01f3706b75" />

- 업데이트 전 / 후 비교입니다 

<img width="822" height="543" alt="스크린샷 2025-09-12 오후 10 45 22" src="https://github.com/user-attachments/assets/9f9f1c08-e30e-4866-82fb-ea8315f43fd4" />

- 이미 완료된 내역을 다시 변경하려고 하면 오류 발생합니다 (이게 합리적인지는 모르겠는데 일단 있어보여서 했습니다)


## 📝 Note (주의 사항)
1. 스케줄링 돌리면서 오늘 12시 땡~ 지나면 프로그레스로 바뀔 수 있도록 해야 할 것 같습니다 
2. 당일 당일 저장하는 걸로 생각하긴 했는데 (투두 리스트), 칸반 보드로 쓸 거면 이렇게 하는 게 맞는 거 같기도... (여러 날에 걸쳐서 보여지도록)
3. 이거 프론트로 하는 게 귀찮겠네요... 역시 백엔드가 좋습니다 
4. style, docs, fix 는 안 보셔도 되고 나머지 feat 만 보시는 게 좋을 듯 합니다 (커밋이 많은 이유는 이를 CRUD를 다 분리했기 때문임... 그래도 보기 편할 듯해요) 