### PR TITLE
✨ feat: 그룹 생성 API 추가 (+ elasticsearch)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,12 @@ dependencies {
 
 	// batch
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
+
+	// elasticsearch
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
+	// mysql
+	runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
+++ b/src/main/java/com/grow/study_service/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     NO_PERMISSION_TO_ACCEPT_REQUEST("403", "요청을 수락할 권한이 없습니다."),
     JOIN_REQUEST_NOT_FOUND("404", "해당 그룹에 참여 요청이 전송되지 않았습니다."),
     INVALID_DATE_RANGE("400", "시작 날짜는 종료 날짜보다 미래일 수 없습니다."),
+    GROUP_ALREADY_EXISTS("409", "해당 이름은 이미 존재하는 그룹입니다. 그룹명과 카테고리를 확인해 주세요." ),
 
     /**
      * 📌 2. 그룹 멤버(Group Member) 관련
@@ -87,7 +88,7 @@ public enum ErrorCode {
      */
     TODO_NOT_FOUND("404", "해당 TO-DO를 찾을 수 없습니다." ),
     CANNOT_CHANGE_STATUS_OF_COMPLETED_TODO("403", "이미 완료된 TO-DO의 상태를 변경할 수 없습니다." ),
-    CANNOT_DELETE_KANBANBOARD("403", "이 TO-DO를 삭제할 권한이 없습니다.");
+    CANNOT_DELETE_KANBANBOARD("403", "이 TO-DO를 삭제할 권한이 없습니다."), ;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/grow/study_service/group/application/create/GroupCreateService.java
+++ b/src/main/java/com/grow/study_service/group/application/create/GroupCreateService.java
@@ -1,0 +1,7 @@
+package com.grow.study_service.group.application.create;
+
+import com.grow.study_service.group.presentation.dto.create.GroupCreateRequest;
+
+public interface GroupCreateService {
+    Long createGroup(GroupCreateRequest request, Long memberId);
+}

--- a/src/main/java/com/grow/study_service/group/application/create/GroupCreateServiceImpl.java
+++ b/src/main/java/com/grow/study_service/group/application/create/GroupCreateServiceImpl.java
@@ -1,0 +1,82 @@
+package com.grow.study_service.group.application.create;
+
+import com.grow.study_service.common.exception.ErrorCode;
+import com.grow.study_service.common.exception.service.ServiceException;
+import com.grow.study_service.group.domain.document.GroupDocument;
+import com.grow.study_service.group.domain.model.Group;
+import com.grow.study_service.group.domain.repository.GroupRepository;
+import com.grow.study_service.group.infra.persistence.repository.elastic.GroupDocumentRepository;
+import com.grow.study_service.group.presentation.dto.create.GroupCreateRequest;
+import com.grow.study_service.groupmember.domain.enums.Role;
+import com.grow.study_service.groupmember.domain.model.GroupMember;
+import com.grow.study_service.groupmember.domain.repository.GroupMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroupCreateServiceImpl implements GroupCreateService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupDocumentRepository groupDocumentRepository;
+
+    /**
+     * 그룹 생성을 수행합니다.
+     *
+     * @param request  - 그룹 생성 요청 DTO 객체 (이름, 카테고리, 설명 등)
+     * @param memberId - 생성자의 아이디 (그룹 리더)
+     * @return 생성된 그룹의 ID
+     */
+    @Override
+    @Transactional
+    public Long createGroup(GroupCreateRequest request, Long memberId) {
+        // 1. 같은 이름으로 생성된 그룹이 있는지 확인하기 (중복 방지)
+        if (groupRepository.existsByGroupName(request.getName())) {
+            throw new ServiceException(ErrorCode.GROUP_ALREADY_EXISTS);
+        }
+
+        // 2. 그룹 생성
+        Group saved = groupRepository.save(createNewGroup(request));
+
+        // 3. 도큐먼트 객체 생성 + 4. 엘라스틱 서치에도 반영되도록 함
+        groupDocumentRepository.save(createNewDocument(saved));
+
+        // 5. 그룹에 그룹 멤버를 추가, 리더로 지정
+        groupMemberRepository.save(GroupMember.create(memberId, saved.getGroupId(), Role.LEADER));
+
+        return saved.getGroupId();
+    }
+
+    private GroupDocument createNewDocument(Group saved) {
+        return new GroupDocument(
+                saved.getGroupId().toString(), // 원본 Long 타입 저장 -> String 타입으로 저장
+                saved.getName(),
+                saved.getDescription(),
+                saved.getCategory(),
+                saved.getStartAt(),
+                saved.getEndAt(),
+                saved.getAmount(),
+                saved.getViewCount(),
+                saved.getPersonalityTag(),
+                saved.getSkillTag()
+        );
+    }
+
+    @NotNull
+    private Group createNewGroup(GroupCreateRequest request) {
+        return Group.create(
+                request.getName(),
+                request.getCategory(),
+                request.getDescription(),
+                request.getPersonalityTag(),
+                request.getSkillTag(),
+                request.getAmount(),
+                request.getEndAt()
+        );
+    }
+}

--- a/src/main/java/com/grow/study_service/group/domain/document/GroupDocument.java
+++ b/src/main/java/com/grow/study_service/group/domain/document/GroupDocument.java
@@ -1,0 +1,69 @@
+package com.grow.study_service.group.domain.document;
+
+import com.grow.study_service.group.domain.enums.Category;
+import com.grow.study_service.group.domain.enums.PersonalityTag;
+import com.grow.study_service.group.domain.enums.SkillTag;
+import lombok.AllArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.*;
+
+import java.time.LocalDateTime;
+
+@Document(indexName = "groups")
+@Setting(settingPath = "/elasticsearch/group-settings.json")
+@AllArgsConstructor
+public class GroupDocument {
+
+    @Id
+    private String id; // 엘라스틱 서치 기본 ID 값은 String 타입으로 저장됨
+
+    // 그룹 이름 -> 유연한 검색 가능, 자동 완성이 가능하게끔 해야 함
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, analyzer = "groups_name_analyzer"), // 한+영 검색 허용
+            otherFields = {
+                    @InnerField(suffix = "auto_complete", type = FieldType.Search_As_You_Type, analyzer = "nori") // 자동 완성은 한글 검색 허용으로
+            }
+    )
+    private String name;
+
+    @Field(type = FieldType.Text, analyzer = "groups_description_analyzer")
+    private String description;
+
+    // 단어 입력 -> [그룹 이름 + 설명 + 카테고리 + 스킬 태그]로 검색 가능 (이 중에 하나에만 속해도 검색이 가능할 수 있도록)
+    // 유연한 타입 + 카테고리로만 필터링 할 때를 위해서 정확한 타입 또한 필요
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, analyzer = "groups_category_analyzer"),
+            otherFields = {
+                    @InnerField(suffix = "raw", type = FieldType.Keyword)
+            }
+    )
+    private Category category;
+
+    @Field(type = FieldType.Date)
+    private LocalDateTime startAt;
+
+    @Field(type = FieldType.Date)
+    private LocalDateTime endAt;
+
+    @Field(type = FieldType.Integer)
+    private int amount;
+
+    @Field(type = FieldType.Long)
+    private int viewCount;
+
+    @Field(type = FieldType.Keyword)
+    private PersonalityTag personalityTag; // 특성 태그 -> Null 가능, List 가능으로 변경 필요함
+
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, analyzer = "groups_skillTag_analyzer"),
+            otherFields = {
+                    @InnerField(suffix = "raw", type = FieldType.Keyword)
+            }
+    )
+    private SkillTag skillTag;
+
+    // 하이라이팅 하기 위함
+    public void updateName(String newName) {
+        this.name = newName;
+    }
+}

--- a/src/main/java/com/grow/study_service/group/domain/model/Group.java
+++ b/src/main/java/com/grow/study_service/group/domain/model/Group.java
@@ -68,14 +68,12 @@ public class Group {
     /**
      * 그룹의 성격/특성 관련 태그.
      */
-    private PersonalityTag personalityTag;
+    private PersonalityTag personalityTag; // 특성 태그 -> Null 가능, List 가능으로 변경 필요함
 
     /**
      * 기술/스킬 관련 태그.
      */
     private SkillTag skillTag;
-
-
 
     private Long version; // 낙관적 락
 

--- a/src/main/java/com/grow/study_service/group/domain/repository/GroupRepository.java
+++ b/src/main/java/com/grow/study_service/group/domain/repository/GroupRepository.java
@@ -12,4 +12,5 @@ public interface GroupRepository {
 	void delete(Group group);
     List<Group> findAllByCategory(Category category);
 	String findGroupNameById(Long groupId);
+	boolean existsByGroupName(String groupName);
 }

--- a/src/main/java/com/grow/study_service/group/infra/persistence/repository/GroupJpaRepository.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/repository/GroupJpaRepository.java
@@ -15,4 +15,6 @@ public interface GroupJpaRepository
 
     @Query("select g.name from GroupJpaEntity g where g.id = :groupId")
     String findGroupNameById(@Param("groupId") Long groupId);
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/grow/study_service/group/infra/persistence/repository/GroupRepositoryImpl.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/repository/GroupRepositoryImpl.java
@@ -53,4 +53,14 @@ public class GroupRepositoryImpl implements GroupRepository {
 	public String findGroupNameById(Long groupId) {
 		return groupJpaRepository.findGroupNameById(groupId);
 	}
+
+	/**
+	 * 주어진 그룹 이름이 이미 존재하는지 확인합니다.
+	 * @param groupName - 검사할 그룹 이름 (필수, null 불가)
+	 * @return 그룹 이름이 이미 존재하는지 여부 (true/false) - 존재하면 true, 없으면 false를 반환합니다.
+	 */
+	@Override
+	public boolean existsByGroupName(String groupName) {
+		return groupJpaRepository.existsByName((groupName));
+	}
 }

--- a/src/main/java/com/grow/study_service/group/infra/persistence/repository/elastic/GroupDocumentRepository.java
+++ b/src/main/java/com/grow/study_service/group/infra/persistence/repository/elastic/GroupDocumentRepository.java
@@ -1,0 +1,7 @@
+package com.grow.study_service.group.infra.persistence.repository.elastic;
+
+import com.grow.study_service.group.domain.document.GroupDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface GroupDocumentRepository extends ElasticsearchRepository<GroupDocument, String> {
+}

--- a/src/main/java/com/grow/study_service/group/presentation/controller/GroupCreateController.java
+++ b/src/main/java/com/grow/study_service/group/presentation/controller/GroupCreateController.java
@@ -1,0 +1,31 @@
+package com.grow.study_service.group.presentation.controller;
+
+import com.grow.study_service.common.rsdata.RsData;
+import com.grow.study_service.group.application.create.GroupCreateService;
+import com.grow.study_service.group.presentation.dto.create.GroupCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/groups")
+public class GroupCreateController {
+
+    private final GroupCreateService groupCreateService;
+
+    // 그룹 생성 API
+    @PostMapping("/create")
+    public ResponseEntity<RsData<Long>> createGroup(@RequestHeader("X-Authorization-Id") Long memberId,
+                                                    @RequestBody GroupCreateRequest request) {
+
+        Long groupId = groupCreateService.createGroup(request, memberId);
+        RsData<Long> response = new RsData<>(
+                "201",
+                "그룹 생성 완료",
+                groupId
+        );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/grow/study_service/group/presentation/dto/create/GroupCreateRequest.java
+++ b/src/main/java/com/grow/study_service/group/presentation/dto/create/GroupCreateRequest.java
@@ -1,0 +1,48 @@
+package com.grow.study_service.group.presentation.dto.create;
+
+import com.grow.study_service.group.domain.enums.Category;
+import com.grow.study_service.group.domain.enums.PersonalityTag;
+import com.grow.study_service.group.domain.enums.SkillTag;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class GroupCreateRequest {
+
+    /** 그룹의 카테고리. 예를 들어, 스터디 주제나 취미 등의 유형을 나타내는 열거형 값입니다. */
+    @NotNull(message = "카테고리는 필수입니다.")
+    private final Category category;
+
+    /** 그룹의 종료 날짜와 시간. 그룹이 종료되기 전까지 유효합니다. */
+    @NotNull(message = "종료 시간은 필수입니다.")
+    @Future(message = "종료 시간은 현재 또는 미래여야 합니다.")
+    private final LocalDateTime endAt;
+
+    /** 그룹의 이름. 업데이트 가능하며, 비어 있지 않아야 합니다. */
+    @NotBlank(message = "그룹 이름은 필수이며, 빈 문자열일 수 없습니다.")
+    private String name;
+
+    /** 그룹의 상세 설명. 업데이트 가능하며, 비어 있지 않아야 합니다. */
+    @NotBlank(message = "상세 설명은 필수이며, 빈 문자열일 수 없습니다.")
+    private String description;
+
+    /** 멘토링 시, 가격 설정 값. (null 허용) */
+    private int amount;
+
+    /** 그룹의 성격/특성 관련 태그. (null 허용) */
+    private PersonalityTag personalityTag;
+
+    /** 기술/스킬 관련 태그. */
+    @NotNull(message = "기술/스킬 태그는 필수입니다.")
+    private SkillTag skillTag;
+
+    // TODO 사전에 추가하고 싶은 사용자가 있는지 물어보기 -> 닉네임 or 이메일로 검색 + 추가
+    private List<String> memberNicknames;
+}

--- a/src/main/resources/elasticsearch/group-settings.json
+++ b/src/main/resources/elasticsearch/group-settings.json
@@ -1,0 +1,53 @@
+{
+  "analysis": {
+    "filter": {
+      "product_synonyms": {
+        "type": "synonym",
+        "synonyms": [
+          "자바, java, spring, 스프링,",
+          "파이썬, python, py, django",
+          "취미, 동호회"
+        ]
+      }
+    },
+    "analyzer": {
+      "groups_name_analyzer": {
+        "char_filter": [],
+        "tokenizer": "nori_tokenizer",
+        "filter": [
+          "nori_part_of_speech",
+          "nori_readingform",
+          "lowercase",
+          "product_synonyms"
+        ]
+      },
+      "groups_description_analyzer": {
+        "char_filter": ["html_strip"],
+        "tokenizer": "nori_tokenizer",
+        "filter": [
+          "nori_part_of_speech",
+          "nori_readingform",
+          "lowercase"
+        ]
+      },
+      "groups_category_analyzer": {
+        "char_filter": [],
+        "tokenizer": "nori_tokenizer",
+        "filter": [
+          "nori_part_of_speech",
+          "nori_readingform",
+          "lowercase"
+        ]
+      },
+      "groups_skillTag_analyzer": {
+        "char_filter": [],
+        "tokenizer": "nori_tokenizer",
+        "filter": [
+          "nori_part_of_speech",
+          "nori_readingform",
+          "lowercase"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## ✅ Check List(필수)
- [X] 코드에 주석 추가 완료
- [X] 테스트 통과 확인

+ 📸 Screenshot or Test Result
## 🔍 Test

<img width="975" height="581" alt="스크린샷 2025-09-24 오후 7 14 48" src="https://github.com/user-attachments/assets/2344bee7-c50f-4a9c-9814-77738d16f45b" />

- api 로 그룹 생성 요청 전송 -> Long 타입의 id 값만 반환합니다

<img width="1409" height="121" alt="스크린샷 2025-09-24 오후 7 15 12" src="https://github.com/user-attachments/assets/d27ae8e0-f447-45e0-b5c3-d1e602c9a349" />
<img width="737" height="81" alt="스크린샷 2025-09-24 오후 7 15 22" src="https://github.com/user-attachments/assets/15dfcfff-ae48-4b4b-b928-6c5f26a17962" />

- 그룹 및 그룹 멤버 저장 확인

<img width="1254" height="598" alt="스크린샷 2025-09-24 오후 7 15 39" src="https://github.com/user-attachments/assets/e865cebc-746f-4230-b7a1-83d73761037c" />

- 엘라스틱 서치에서도 저장됨을 확인

---

## 📝 Note (주의 사항)
사실 엘라스틱 서치는 CDC(Change Data Capture) 도구와 연동해서 사용해야 한다고 합니다... 
CDC 도구는 데이터 변경을 실시간으로 감지하고 기록하는 기술인데, 이 변화를 자동으로 감지해서 다른 시스템으로 알리는 겁니다
대표 도구: Debezium(Kafka 기반 오픈소스 도구)
그래서 원래의 매커니즘은
1. DB에 그룹 생성 저장
2. CDC 도구가 자동으로 이를 감지
3. CDC 도구는 캡처한 변경 이벤트를 Kafka 토픽으로 전송
4. Kafka Consumer 를 사용해 토픽을 구독하고, 수신된 이벤트를 파싱해 Elasticsearch에 upsert
입니다 
그렇지만 저는? CDC 도구까지 더 공부할 여력이 없었습니다...
다 완성하고 난 후에 이제 천천히 디벨롭 할 여력이 생긴다면 그때 해 보려고 합니다... 
그때쯤 이미 취업을 했다면... 안 하겠지요... 

사실 엘라스틱 서치를 따로 알지 않으면 Document 생성, setting 값 보고 이 이게 뭔데 씹덕아 할 수 있습니다!!!
그러니까 코드 너무 이해하려고 하지 않으셔도 될 것 같고 엘라스틱 서치 레포지토리도 JPA 와 같은 매커니즘을 이용하는구나 스프링 부트는 이를 통합시켯구나 정말 대단하다 생각하시면 되겟습니다
이어서 쿼리 로직 올리도록 하죠/... (자동완성 + 검색)